### PR TITLE
tloz_ph V0.5.3-alpha

### DIFF
--- a/worlds/tloz_ph/Client.py
+++ b/worlds/tloz_ph/Client.py
@@ -437,7 +437,8 @@ class PhantomHourglassClient(BizHawkClient):
                         self.watches.pop(loc_name)
 
             # Check if link is getting location
-            if getting_location and not self.receiving_location and self.locations_in_scene is not None:
+            if getting_location and not self.receiving_location and self.locations_in_scene is not None \
+                    and self.new_stage_loading is None:
                 self.receiving_location = True
                 print("Receiving Item")
                 await self.process_checked_locations(ctx, None)

--- a/worlds/tloz_ph/Logic.py
+++ b/worlds/tloz_ph/Logic.py
@@ -14,7 +14,7 @@ def make_overworld_logic(player: int, origin_name: str, options: PhantomHourglas
         ["mercay island", "mercay dig spot", False, lambda state: ph_has_shovel(state, player)],
         ["mercay island", "mercay zora cave", False, lambda state: ph_has_explosives(state, player)],
         ["mercay zora cave", "mercay zora cave south", False, lambda state: ph_has_bow(state, player)],
-        ["mercay island", "sw ocean", False, lambda state: ph_has_sea_chart(state, player, "SW")],
+        ["mercay island", "mercay zora cave south", False, lambda state: ph_can_sword_scroll_clip(state, player)],
         ["mercay island", "totok", False, None],
         ["mercay island", "mercay freedle island", False, lambda state: ph_has_explosives(state, player)],
         ["mercay freedle island", "mercay freedle tunnel chest", False, lambda state: ph_has_range(state, player)],
@@ -23,12 +23,15 @@ def make_overworld_logic(player: int, origin_name: str, options: PhantomHourglas
         ["post tow", "mercay oshus gem", False, None],
         ["mercay island", "mercay oshus phantom blade", False, lambda state: ph_has_phantom_blade(state, player)],
         ["mercay oshus phantom blade", "mercay oshus gem", False, None],
+        ["mercay island", "sw ocean", False, lambda state: ph_has_sea_chart(state, player, "SW")],
 
         # ======== Mountain Passage =========
 
         ["mercay island", "mercay passage 1", False, lambda state:
             any([ph_can_cut_small_trees(state, player),
-                ph_has_small_keys(state, player, "Mountain Passage", 3)])],
+                ph_has_small_keys(state, player, "Mountain Passage", 3),
+                ph_option_glitched_logic(state, player)  # Savewarp in back entrance / reverse cuccoo jump
+                 ])],
         ["mercay island", "mercay passage 2", False, lambda state: ph_can_reach_MP2(state, player)],
         ["mercay passage 2", "mercay passage rat", False, lambda state: ph_mercay_passage_rat(state, player)],
 
@@ -173,7 +176,9 @@ def make_overworld_logic(player: int, origin_name: str, options: PhantomHourglas
         # =============== Isle of Ember ================
 
         ["ember island", "ember island dig", False, lambda state: ph_has_shovel(state, player)],
-        ["ember island", "ember island grapple", False, lambda state: ph_has_grapple(state, player)],
+        ["ember island", "ember island grapple", False, lambda state: any([
+            ph_has_grapple(state, player),
+            ph_can_sword_glitch(state, player)])],
         ["ember island", "tof 1f", False, None],
 
         # =============== Temple of Fire =================
@@ -216,7 +221,8 @@ def make_overworld_logic(player: int, origin_name: str, options: PhantomHourglas
         ["toc", "toc bomb alcove", False, lambda state: ph_has_explosives(state, player)],
         ["toc", "toc b1", False, lambda state: ph_toc_key_door_1(state, player)],
         ["toc", "toc hammer clips", False, lambda state: ph_can_hammer_clip(state, player)],
-        ["toc b1", "toc b1 grapple", False, lambda state: ph_has_grapple(state, player)],
+        ["toc b1", "toc b1 grapple", False, lambda state: any([ph_has_grapple(state, player),
+                                                               ph_can_boomerang_return(state, player)])],
         ["toc b1", "toc 1f west", False, lambda state: ph_has_explosives(state, player)],
         ["toc b1 grapple", "toc 1f west", False, lambda state: ph_has_bow(state, player)],
         ["toc hammer clips", "toc 1f west", False, None],

--- a/worlds/tloz_ph/__init__.py
+++ b/worlds/tloz_ph/__init__.py
@@ -49,7 +49,6 @@ def add_items_from_filler(item_pool_dict: dict, filler_item_count: int, item: st
 def add_additional_spirit_gems(item_pool_dict: dict, filler_item_count: int):
     def add_gems(gem: str, filler_count: int):
         gems = 20 - item_pool_dict[gem]
-        print(f"Processing {gem}: adding {gems}")
         if filler_count >= gems:
             filler_count -= gems
             item_pool_dict[gem] = 20
@@ -94,7 +93,6 @@ class PhantomHourglassWorld(World):
         self.excluded_dungeons = []
 
     def generate_early(self):
-        print("GENERATING EARLY")
         self.pick_required_dungeons()
         self.restrict_non_local_items()
 
@@ -103,6 +101,7 @@ class PhantomHourglassWorld(World):
         # to be placed locally (e.g. dungeon items with keysanity off)
         if not self.options.keysanity == "anywhere":
             self.options.non_local_items.value -= self.item_name_groups["Small Keys"]
+        self.options.non_local_items.value -= set(self.boss_reward_items_pool)
 
     def create_location(self, region_name: str, location_name: str, local: bool):
         region = self.multiworld.get_region(region_name, self.player)
@@ -141,7 +140,6 @@ class PhantomHourglassWorld(World):
         location = Location(self.player, region_name + ".event", None, region)
         region.locations.append(location)
         location.place_locked_item(Item(event_item_name, ItemClassification.progression, None, self.player))
-        print(f"Created Event for {event_item_name} at {region_name}")
 
     def location_is_active(self, location_name, location_data):
         if not location_data.get("conditional", False):
@@ -181,7 +179,6 @@ class PhantomHourglassWorld(World):
         dungeons_required = len(implemented_dungeons) if self.options.dungeons_required > len(implemented_dungeons) \
             else self.options.dungeons_required.value
         self.options.dungeons_required.value = dungeons_required
-        print(f"dungeons required {self.options.dungeons_required.value}")
         self.required_dungeons = implemented_dungeons[:dungeons_required]
 
         # Extend mcguffin list
@@ -231,13 +228,10 @@ class PhantomHourglassWorld(World):
             always_include = ["Temple of the Ocean King", "Mountain Passage"]
             if self.options.ghost_ship_in_dungeon_pool == "false":
                 always_include.append("Ghost Ship")
-            print(f"required dungeons {self.required_dungeons}")
             excluded_dungeons = [d for d in DUNGEON_NAMES
                                  if d not in self.required_dungeons + always_include]
-            print(f"excluded dungeons {excluded_dungeons}")
             self.excluded_dungeons = excluded_dungeons
             for dungeon in excluded_dungeons:
-                print(f"Excluding: {self.dungeon_name_groups[dungeon]}")
                 locations_to_exclude.update(self.dungeon_name_groups[dungeon])
 
             self.ut_locations_to_exclude = locations_to_exclude.copy()
@@ -265,7 +259,6 @@ class PhantomHourglassWorld(World):
             classification = ItemClassification.progression
 
         ap_code = self.item_name_to_id[name]
-        print(f"Created item {name} as {CLASSIFICATION[classification]}")
         return Item(name, classification, ap_code, self.player)
 
     def build_item_pool_dict(self):
@@ -275,26 +268,24 @@ class PhantomHourglassWorld(World):
         rupee_item_count = 0
         boss_reward_item_count = self.options.dungeons_required
         for loc_name, loc_data in LOCATIONS_DATA.items():
-            print(f"New Location: {loc_name}")
+            # print(f"New Location: {loc_name}")
             if not self.location_is_active(loc_name, loc_data):
-                print(f"{loc_name} is not active")
+                # print(f"{loc_name} is not active")
                 continue
             # If no defined vanilla item, fill with filler
             if "vanilla_item" not in loc_data:
-                print(f"{loc_name} has no defined vanilla item")
+                # print(f"{loc_name} has no defined vanilla item")
                 filler_item_count += 1
                 continue
 
             item_name = loc_data.get("item_override", loc_data["vanilla_item"])
             if item_name in removed_item_quantities and removed_item_quantities[item_name] > 0:
                 # If item was put in the "remove_items_from_pool" option, replace it with a random filler item
-                print(f"{item_name} @ {loc_name} was removed from pool")
                 removed_item_quantities[item_name] -= 1
                 filler_item_count += 1
                 continue
             if item_name == "Filler Item":
                 filler_item_count += 1
-                print(f"added filler item @ {loc_name}")
                 continue
             if self.options.keysanity == "vanilla":
                 # Place small key in vanilla location
@@ -303,7 +294,6 @@ class PhantomHourglassWorld(World):
                     self.multiworld.get_location(loc_name, self.player).place_locked_item(key_item)
                     continue
             if "force_vanilla" in loc_data and loc_data["force_vanilla"]:
-                print(f"Forcing {loc_name} with item {item_name}")
                 forced_item = self.create_item(item_name)
                 self.multiworld.get_location(loc_name, self.player).place_locked_item(forced_item)
                 continue
@@ -311,7 +301,6 @@ class PhantomHourglassWorld(World):
                 # if dungeon is excluded, place keys in vanilla locations
                 dung = item_name.rsplit('(', 1)[1][:-1]
                 if self.options.exclude_non_required_dungeons and dung in self.excluded_dungeons:
-                    print(f"Forcing {loc_name} with item {item_name} because excluded dungeon")
                     forced_item = self.create_item(item_name)
                     self.multiworld.get_location(loc_name, self.player).place_locked_item(forced_item)
                     continue
@@ -323,26 +312,22 @@ class PhantomHourglassWorld(World):
             if item_name == "Rare Metal":  # Change rare metals to filler items for unrequired dungeons
                 if boss_reward_item_count <= 0:
                     filler_item_count += 1
-                    print(f"added filler item @ {loc_name}")
                     continue
                 item_name = self.boss_reward_items_pool[boss_reward_item_count - 1]
                 boss_reward_item_count -= 1
             if item_name == "Triforce Crest" and not self.options.randomize_triforce_crest:
                 filler_item_count += 1
-                print(f"added filler item @ {loc_name}")
                 continue
             if (item_name in ["Treasure", "Ship Part", "Nothing!", "Potion", "Red Potion", "Purple Potion",
                               "Yellow Potion", "Power Gem", "Wisdom Gem", "Courage Gem", "Heart Container"]
                     or "Treasure Map" in item_name):
                 filler_item_count += 1
-                print(f"added filler item @ {loc_name}")
                 continue
 
             item_pool_dict[item_name] = item_pool_dict.get(item_name, 0) + 1
 
         # Fill filler count with consistent amounts of items, when filler count is empty it won't add any more items
         # so add progression items first
-        print(f"Finished making item dict from locations, filler count {filler_item_count}")
         add_items = [("Wisdom Gem", 20), ("Power Gem", 20), ("Courage Gem", 20), ("Heart Container", 13)]
         for i, count in add_items:
             item_pool_dict, filler_item_count = add_items_from_filler(item_pool_dict, filler_item_count, i, count)
@@ -381,8 +366,6 @@ class PhantomHourglassWorld(World):
                 filler_count += count
 
         extra_item_count = len(self.locations_to_exclude) - filler_count + 20
-        print(f"Excluded locations: {len(self.locations_to_exclude)}, filler items: {filler_count}, "
-              f"extra items {extra_item_count}, eligible items: {len(extra_items_list)}")
         if extra_item_count > 0:
             self.random.shuffle(extra_items_list)
             self.extra_filler_items = extra_items_list[:extra_item_count]
@@ -407,7 +390,6 @@ class PhantomHourglassWorld(World):
         for item in confined_dungeon_items:
             items.remove(item)
         self.pre_fill_items.extend(confined_dungeon_items)
-        print(f"Filtered pre fill items {self.pre_fill_items}")
 
     def pre_fill_boss_rewards(self):
         boss_reward_location_names = [DUNGEON_TO_BOSS_ITEM_LOCATION[dung_name] for dung_name in self.required_dungeons]
@@ -424,11 +406,10 @@ class PhantomHourglassWorld(World):
         # Remove from the all_state the items we're about to place
         for item in boss_reward_items:
             self.pre_fill_items.remove(item)
+
         collection_state = self.multiworld.get_all_state(False)
         # Perform a prefill to place confined items inside locations of this dungeon
         self.random.shuffle(boss_reward_locations)
-        print(f"Removing items {boss_reward_items}")
-        print(f"Filling locations {boss_reward_locations}")
         fill_restrictive(self.multiworld, collection_state, boss_reward_locations, boss_reward_items,
                          single_player_placement=True, lock=True, allow_excluded=True)
 
@@ -459,8 +440,6 @@ class PhantomHourglassWorld(World):
             collection_state = self.multiworld.get_all_state(False)
             # Perform a prefill to place confined items inside locations of this dungeon
             self.random.shuffle(dungeon_locations)
-            print(f"Removing items {confined_dungeon_items}")
-            print(f"Filling locations {dungeon_locations}")
             fill_restrictive(self.multiworld, collection_state, dungeon_locations, confined_dungeon_items,
                              single_player_placement=True, lock=True, allow_excluded=True)
 
@@ -491,7 +470,6 @@ class PhantomHourglassWorld(World):
         slot_data["locations_to_exclude"] = self.ut_locations_to_exclude
         slot_data["boss_rewards"] = self.boss_reward_items_pool
         slot_data["required_dungeon_locations"] = self.boss_reward_location_names
-        print(f"Slot Data: {slot_data}")
         return slot_data
 
     def write_spoiler(self, spoiler_handle):

--- a/worlds/tloz_ph/__init__.py
+++ b/worlds/tloz_ph/__init__.py
@@ -261,10 +261,11 @@ class PhantomHourglassWorld(World):
         if name in self.extra_filler_items:
             self.extra_filler_items.remove(name)
             classification = ItemClassification.filler
+        if name == "Swordsman's Scroll" and self.options.logic == "glitched":
+            classification = ItemClassification.progression
 
         ap_code = self.item_name_to_id[name]
-        if classification == ItemClassification.filler:
-            print(f"Created item {name} as {CLASSIFICATION[classification]}")
+        print(f"Created item {name} as {CLASSIFICATION[classification]}")
         return Item(name, classification, ap_code, self.player)
 
     def build_item_pool_dict(self):

--- a/worlds/tloz_ph/data/DynamicFlags.py
+++ b/worlds/tloz_ph/data/DynamicFlags.py
@@ -417,8 +417,8 @@ DYNAMIC_FLAGS = {
         "set_if_true": [(0x1B5582, 0x80), (0x1B55AB, 0x10)]
     },
     "Respawn ghost ship": {
-        "on_scenes": [0x1],
-        "not_last_scenes": [0x2903, 0x400],
+        "on_scenes": [0x1],  # NW quadrant
+        "not_last_scenes": [0x2903, 0x400],  # from ghost ship
         "has_locations": ["Ghost Ship Rescue Tetra"],
         "any_not_has_locations": ["Ghost Ship B1 Entrance Chest",
                                   "Ghost Ship B1 Second Sister Chest",
@@ -428,8 +428,8 @@ DYNAMIC_FLAGS = {
                                   "Ghost Ship B3 Chest",
                                   "Ghost Ship Cubus Sisters Ghost Key",
                                   "Ghost Ship Cubus Sisters Heart Container"],
-        "set_if_true": [(0x1B557E, 0x10), (0x1B55AB, 0x10)],
-        "unset_if_true": [(0x1B5582, 0x80)]
+        "set_if_true": [(0x1B557E, 0x10), (0x1B55AB, 0x10)],  # Spawn spirits, remove fog
+        "unset_if_true": [(0x1B5582, 0x80)]  # Respawn ghost ship
     },
     "RESET Respawn ghost ship": {
         "on_scenes": [0x1],
@@ -661,7 +661,7 @@ DYNAMIC_FLAGS = {
         "has_items": [("Crimzonine", 1)],
         "set_if_true": [(0x1B558B, 0x40)]
     },
-    "Tce temple metals": {
+    "Ice temple metals": {
         "on_scenes": [0x1F00],
         "unset_if_true": [(0x1B558B, 0x20)]
     },
@@ -703,7 +703,7 @@ DYNAMIC_FLAGS = {
     },
     "Oshus Gem": {
         "on_scenes": [0xB0A],
-        "not_has_locations": ["Mercay Oshus Item After Temple of Wind"],
+        "not_has_locations": ["Mercay Oshus Force Gem"],
         "has_locations": ["Temple of Wind Cyclok Dungeon Reward"],
         "set_if_true": [(0x1B55A0, 0x4), (0x1B557D, 0x2)]
     },
@@ -816,22 +816,22 @@ DYNAMIC_FLAGS = {
         "set_if_true": [(0x1B5590, 0x02)],  # Memory of water
     },
     "Ice Field pre-dungeon": {
-        "on_scenes": [0xF03],
+        "on_scenes": [0xF03, 0xF01],
         "not_has_locations": ["Temple of Ice Dungeon Reward"],
         "unset_bits": [(0x1B558B, 0x20)]
     },
     "Ice Field post-dungeon": {
-        "on_scenes": [0xF03],
+        "on_scenes": [0xF03, 0xF01],
         "has_locations": ["Temple of Ice Dungeon Reward"],
         "set_bits": [(0x1B558B, 0x20)]
     },
     "RESET Ice Field pre-dungeon": {
-        "on_scenes": [0xF13, 0xF01],
+        "on_scenes": [0xF13, 0x1F00],
         "has_items": [("Azurine", 1)],
         "set_bits": [(0x1B558B, 0x20)]
     },
     "RESET Ice Field post-dungeon": {
-        "on_scenes": [0xF13, 0xF01],
+        "on_scenes": [0xF13, 0x1F00],
         "has_items": [("Azurine", 0)],
         "unset_bits": [(0x1B558B, 0x20)]
     },

--- a/worlds/tloz_ph/data/Items.py
+++ b/worlds/tloz_ph/data/Items.py
@@ -17,7 +17,8 @@ ITEMS_DATA = {
 
     "Sword (Progressive)": {
         'classification': ItemClassification.progression,
-        'progressive': [[0x1BA644, 1], [0x1BA648, 32]]
+        'progressive': [[0x1BA644, 1], [0x1BA648, 32]],
+        'set_bit': [(0x1BA644, 1)]  # Means that sending sword if sword breaks gives the base layer
     },
     "Shield": {
         'classification': ItemClassification.progression,

--- a/worlds/tloz_ph/data/Locations.py
+++ b/worlds/tloz_ph/data/Locations.py
@@ -1,4 +1,4 @@
-from .Constants import *
+
 
 # TODO: Add sram data for saveslot 2
 # TODO: Add the rest of sram data in bulk
@@ -1864,16 +1864,6 @@ LOCATIONS_DATA = {
         "x_max": -25000,
         "z_min": 45000
     },
-    "Dee Ess Blow in Microphone Chest": {
-        "region_id": "ds",
-        "stage_id": 0x1B,
-        "floor_id": 0x0,
-        "vanilla_item": "Gold Rupee (300)",
-        "y": 0,
-        "x_max": -15000,
-        "z_min": 10000,
-        "z_max": 30000,
-    },
     "Dee Ess Left Speakers Dig SSW": {
         "region_id": "ds dig",
         "stage_id": 0x1B,
@@ -2463,6 +2453,18 @@ LOCATIONS_DATA = {
         "value": 0x10
     },
 
+    # ==== New checks at bottom to preserve id ordering
+    "Dee Ess Blow in Microphone Chest": {
+        "region_id": "ds",
+        "stage_id": 0x1B,
+        "floor_id": 0x0,
+        "vanilla_item": "Gold Rupee (300)",
+        "y": 0,
+        "x_max": -15000,
+        "z_min": 10000,
+        "z_max": 30000,
+    },
+
 
 
 }
@@ -2470,3 +2472,6 @@ LOCATIONS_DATA = {
 for i, name in enumerate(LOCATIONS_DATA):
     LOCATIONS_DATA[name]["id"] = i+1
 
+if __name__ == "__main__":
+    for location, data in LOCATIONS_DATA.items():
+        print(f"{location} | {data['region_id']} | id: {data['id']} | stage: {data['stage_id']} | room: {data['floor_id']}")

--- a/worlds/tloz_ph/data/Locations.py
+++ b/worlds/tloz_ph/data/Locations.py
@@ -1708,7 +1708,7 @@ LOCATIONS_DATA = {
         "x_max": 50000
     },
     "Goron Island North Spike Chest": {
-        "region_id": "goron north",
+        "region_id": "goron outside temple",
         "stage_id": 0x10,
         "floor_id": 0x1,
         "vanilla_item": "Power Gem",
@@ -1863,6 +1863,16 @@ LOCATIONS_DATA = {
         "y": 0,
         "x_max": -25000,
         "z_min": 45000
+    },
+    "Dee Ess Blow in Microphone Chest": {
+        "region_id": "ds",
+        "stage_id": 0x1B,
+        "floor_id": 0x0,
+        "vanilla_item": "Gold Rupee (300)",
+        "y": 0,
+        "x_max": -15000,
+        "z_min": 10000,
+        "z_max": 30000,
     },
     "Dee Ess Left Speakers Dig SSW": {
         "region_id": "ds dig",

--- a/worlds/tloz_ph/data/LogicPredicates.py
+++ b/worlds/tloz_ph/data/LogicPredicates.py
@@ -631,6 +631,26 @@ def ph_can_arrow_despawn(state: CollectionState, player: int):
         ph_option_glitched_logic(state, player)
     ])
 
+def ph_can_bcl(state, player):
+    # Bombchu Camera Lock
+    return all([
+        ph_has_chus(state, player),
+        ph_option_glitched_logic(state, player)
+    ])
+
+def ph_can_sword_glitch(state, player):
+    return all([
+        ph_has_sword(state, player),
+        ph_option_glitched_logic(state, player)
+    ])
+
+def ph_can_sword_scroll_clip(state, player):
+    return all([
+        ph_has_sword(state, player),
+        state.has("Swordsman's Scroll", player),
+        ph_option_glitched_logic(state, player)
+    ])
+
 
 # ====== Specific locations =============
 
@@ -863,7 +883,10 @@ def ph_can_reach_MP2(state: CollectionState, player: int):
         ]),
         all([
             ph_option_keys_in_own_dungeon(state, player),
-            ph_can_cut_small_trees(state, player),
+            any([
+                ph_can_cut_small_trees(state, player),
+                ph_option_glitched_logic(state, player)  # SW in back entrance / reversse cuccoo jump
+            ]),
             any([
                 ph_has_small_keys(state, player, "Mountain Passage"),
                 ph_is_ut(state, player)
@@ -1087,7 +1110,8 @@ def ph_toi_b2(state, player):
         ph_quick_switches(state, player),
         any([
             ph_toi_key_doors(state, player, 3, 2),
-            ph_can_hammer_clip(state, player)
+            ph_can_hammer_clip(state, player),
+            ph_can_bcl(state, player)
         ])
     ])
 

--- a/worlds/tloz_ph/data/dummy_logic_parser.py
+++ b/worlds/tloz_ph/data/dummy_logic_parser.py
@@ -1,0 +1,410 @@
+from worlds.tloz_ph.data.LogicPredicates import *
+from BaseClasses import CollectionState
+import inspect
+
+
+# This file is for reformatting logic data
+
+player = 0
+
+overworld_logic = [
+# ====== Mercay Island ==============
+
+    ['mercay island', 'mercay dig spot', False, "ph_has_shovel(state, player)"],
+    ['mercay island', 'mercay zora cave', False, "ph_has_explosives(state, player)"],
+    ['mercay zora cave', 'mercay zora cave south', False, "ph_has_bow(state, player)"],
+    ['mercay island', 'mercay zora cave south', False, "ph_can_sword_scroll_clip(state, player)"],
+    ['mercay island', 'totok', False, None],
+    ['mercay island', 'mercay freedle island', False, "ph_has_explosives(state, player)"],
+    ['mercay freedle island', 'mercay freedle tunnel chest', False, "ph_has_range(state, player)"],
+    ['mercay freedle island', 'mercay freedle gift', False, "ph_has_sea_chart(state, player, 'SE')"],
+    ['mercay island', 'mercay yellow guy', False, "ph_has_courage_crest(state, player)"],
+    ['post tow', 'mercay oshus gem', False, None],
+    ['mercay island', 'mercay oshus phantom blade', False, "ph_has_phantom_blade(state, player)"],
+    ['mercay oshus phantom blade', 'mercay oshus gem', False, None],
+    ['mercay island', 'sw ocean', False, "ph_has_sea_chart(state, player, 'SW')"],
+
+    # ======== Mountain Passage =========
+
+    ['mercay island', 'mercay passage 1', False, "any([ph_can_cut_small_trees(state, player), ph_has_small_keys(state, player, 'Mountain Passage', 3),ph_option_glitched_logic(state, player)])"],
+    ['mercay island', 'mercay passage 2', False, "ph_can_reach_MP2(state, player)"],
+    ['mercay passage 2', 'mercay passage rat', False, "ph_mercay_passage_rat(state, player)"],
+
+    # ========== TotOK ===================
+    ['totok', 'totok 1f chart chest', False, "any([ph_has_small_keys(state, player, 'Temple of the Ocean King', 1),ph_ut_small_key_vanilla_location(state, player),ph_totok_b1_all_checks_ut(state, player)])"],
+    # B1
+    ['totok', 'totok b1', False, "ph_has_spirit(state, player, 'Power')"],
+    ['totok b1', 'totok b1 eye chest', False, "all([ph_has_grapple(state, player),ph_has_bow(state, player)])"],
+    ['totok b1', 'totok b1 phantom chest', False, "ph_can_kill_phantoms(state, player)"],
+    ['totok b1', 'totok b1 key', False, "any([ph_has_explosives(state, player),ph_has_grapple(state, player),ph_has_boomerang(state, player)])"],
+    ['totok b1 key', 'totok b2', False, "any([ph_ut_small_key_vanilla_location(state, player),ph_totok_b1_all_checks_ut(state, player)])"],
+    ['totok b1', 'totok b2', False, "ph_has_small_keys(state, player, 'Temple of the Ocean King', 2)"],
+    # B2
+    ['totok b2', 'totok b2 key', False, "ph_totok_b2_key(state, player)"],
+    ['totok b2', 'totok b2 bombchu chest', False, "all([ph_can_hit_bombchu_switches(state, player),ph_has_explosives(state, player)])"],
+    ['totok b2', 'totok b2 phantom chest', False, "all([ph_has_phantom_sword(state, player),any([ph_can_hit_tricky_switches(state, player),ph_has_explosives(state, player)])])"],
+    ['totok b2 key', 'totok b3', False, "any([ph_ut_small_key_vanilla_location(state, player),ph_totok_b2_all_checks_ut(state, player)])"],
+    ['totok b2', 'totok b3', False, "ph_has_small_keys(state, player, 'Temple of the Ocean King', 3)"],
+    # B3
+    ['totok b3', 'totok b3 phantom chest', False, "all([ph_can_kill_phantoms_traps(state, player),ph_has_grapple(state, player)])"],
+    ['totok b3', 'totok b3 locked chest', False, "any([ph_has_small_keys(state, player, 'Temple of the Ocean King', 4),ph_ut_small_key_vanilla_location(state, player)])"],  # UT
+    ['totok b3 locked chest', 'totok b3.5', False, "ph_is_ut(state, player)"],  # UT ignores force gems
+    ['totok b3', 'totok b3 bow chest', False, "ph_has_bow(state, player)"],
+    ['totok b3', 'totok b3.5', False, "ph_totok_b4_access(state, player)"],
+    ['totok b3.5', 'totok b4', False, "all([ph_has_spirit(state, player, 'Wisdom'),ph_can_hit_tricky_switches(state, player)])"],
+    # B4
+    ['totok b4', 'totok b4 phantom chest', False, "ph_has_phantom_sword(state, player)"],
+    ['totok b4', 'totok b4 key', False, "any([ph_has_explosives(state, player),ph_can_boomerang_return(state, player)])"],
+    ['totok b4', 'totok b5', False, "ph_totok_b5_key_logic(state, player)"],
+    ['totok b5', 'totok b5 chest', False, "ph_totok_b5(state, player)"],
+    ['totok b5 chest', 'totok b6', False, None],
+    ['totok b4', 'totok b5.5', False, "all([ph_totok_b5_key_logic(state, player),ph_can_hit_bombchu_switches(state, player)])"],
+    ['totok b5.5', 'totok b5.5 chest', False, "ph_has_shovel(state, player)"],
+    ['totok b5.5', 'totok b6', False, None],
+    # B6
+    ['totok b6', 'totok b6 phantom chest', False, "ph_has_phantom_sword(state, player)"],
+    ['totok b6', 'totok b6 bow chest', False, "ph_has_bow(state, player)"],
+    ['totok b6', 'totok b6 cc', False, "ph_has_sea_chart(state, player, 'SW')"],
+    ['totok b6', 'totok midway', False, "ph_has_triforce_crest(state, player)"],
+
+    # ============ TotOK Part 2 =====================
+
+    # B7
+    ['totok midway', 'totok b7', False, "ph_has_spirit(state, player, 'Courage')"],
+    ['totok b7', 'totok b8', False, None],
+    ['totok b7', 'totok b7 east', False, "ph_has_grapple(state, player)"],
+    ['totok b7 east', 'totok b7 peg', False, "ph_has_range(state, player)"],
+    ['totok b7', 'totok b7 phantom', False, "ph_can_kill_phantoms(state, player)"],
+    # B8
+    ['totok b8', 'totok b7 east', False, "ph_can_hit_switches(state, player)"],
+    ['totok b8', 'totok b9 nw', False, "any([ph_has_totok_crystal(state, player, 'Round'),ph_has_hammer(state, player)])"],
+    ['totok b7 east', 'totok b9 nw', False, "ph_is_ut(state, player)"],  # UT Bypass
+    ['totok b8', 'totok b8 phantom', False, "ph_can_kill_phantoms(state, player)"],
+    ['totok b8', 'totok b8 2 crystals', False, "ph_totok_b8_2_crystals(state, player)"],
+    ['totok b8', 'totok b9', False, "ph_totok_b9(state, player)"],  # Includes UT
+    # B9
+    ['totok b9', 'totok b9 ghosts', False, "ph_can_hit_switches(state, player)"],
+    ['totok b9', 'totok b9 nw', False, "ph_totok_b9_phantom_square(state, player)"],
+    ['totok b9', 'totok b9 phantom', False, "ph_totok_b9_phantom_kill(state, player)"],
+    ['totok b9', 'totok b9.5', False, "ph_totok_b95(state, player)"],  # UT Crystals
+    ['totok b9.5', 'totok b10', False, None],
+    # B10
+    ['totok b10', 'totok b10 inner', False, "ph_has_explosives(state, player)"],
+    ['totok b10 inner', 'totok b10 hammer', False, "ph_has_hammer(state, player)"],
+    ['totok b10 inner', 'totok b10 phantom', False, "ph_can_kill_phantoms_traps(state, player)"],
+    ['totok b10 inner', 'totok b10 phantom eyes', False, "ph_has_grapple(state, player)"],
+    ['totok b10 inner', 'totok b11', False, "ph_totok_b10_key_logic(state, player)"],
+    # B11
+    ['totok b11', 'totok b11 phantom', False, "ph_has_phantom_sword(state, player)"],
+    ['totok b11', 'totok b12', False, "ph_totok_b12(state, player)"],
+    # B12
+    ['totok b12', 'totok b12 hammer', False, "ph_has_hammer(state, player)"],
+    ['totok b12', 'totok b12 phantom', False, "ph_has_phantom_sword(state, player)"],
+    ['totok b12', 'totok b13', False, "ph_totok_b12_force_gems(state, player)"],  # UT Force gems
+
+    # B13
+    ['totok b13', 'totok before bellum', False, "ph_totok_b13_door(state, player)"],
+    ['totok', 'totok before bellum', False, "ph_totok_blue_warp(state, player)"],
+    # Bellum
+    ['totok', 'bellum 1', False, "ph_totok_bellum_staircase(state, player)"],
+    ['bellum 1', 'ghost ship fight', False, "ph_can_beat_bellum(state, player)"],
+    ['ghost ship fight', 'bellumbeck', False, "ph_can_beat_ghost_ship_fight(state, player)"],
+
+    # ============ Shops ====================
+
+    ['mercay island', 'shop power gem', False, "ph_can_buy_gem(state, player)"],
+    ['mercay island', 'shop quiver', False, "ph_can_buy_quiver(state, player)"],
+    ['mercay island', 'shop bombchu bag', False, "ph_can_buy_chu_bag(state, player)"],
+    ['mercay island', 'shop heart container', False, "ph_can_buy_heart(state, player)"],
+
+    ['sw ocean east', 'beedle gem', False, "ph_beedle_shop(state, player, 500)"],
+    ['sw ocean east', 'beedle bomb bag', False, "all([ph_beedle_shop(state, player, 500),ph_has_bombs(state, player)])"],
+    ['sw ocean east', 'masked ship gem', False, "ph_beedle_shop(state, player, 500)"],
+    ['sw ocean east', 'masked ship hc', False, "ph_beedle_shop(state, player, 500)"],
+
+    # ============ SW Ocean =================
+
+    ['mercay island', 'sw ocean east', False, "ph_boat_access(state, player)"],
+    ['sw ocean east', 'cannon island', False, None],
+    ['sw ocean east', 'ember island', False, None],
+    ['sw ocean east', 'sw ocean crest salvage', False, "ph_salvage_courage_crest(state, player)"],
+    ['sw ocean east', 'sw ocean west', False, "ph_can_enter_ocean_sw_west(state, player)"],
+    ['sw ocean west', 'molida island', False, None],
+    ['sw ocean west', 'spirit island', False, None],
+    ['sw ocean west', 'sw ocean nyave', False, "ph_has_cave_damage(state, player)"],
+    ['sw ocean nyave', 'sw ocean nyave trade', False, "ph_has_guard_notebook(state, player)"],
+    ['sw ocean west', 'sw ocean frog phi', False, "ph_has_cannon(state, player)"],
+    ['sw ocean east', 'sw ocean frog x', False, "ph_has_cannon(state, player)"],
+
+    # ============ Cannon Island ===============
+
+    ['cannon island', 'cannon island salvage arm', False, "ph_has_courage_crest(state, player)"],
+    ['cannon island', 'cannon island dig', False, "ph_has_shovel(state, player)"],
+
+    # =============== Isle of Ember ================
+
+    ['ember island', 'ember island dig', False, "ph_has_shovel(state, player)"],
+    ['ember island', 'ember island grapple', False, "any([ph_has_grapple(state, player),ph_can_sword_glitch(state, player)])"],
+    ['ember island', 'tof 1f', False, None],
+
+    # =============== Temple of Fire =================
+
+    ['tof 1f', 'tof 1f keese', False, "ph_can_kill_bat(state, player)"],
+    ['tof 1f', 'tof 1f maze', False, "any([ph_has_small_keys(state, player, 'Temple of Fire', 1),ph_tof_1f_key_ut(state, player)])"],
+    ['tof 1f maze', 'tof 2f', False, "ph_can_hit_spin_switches(state, player)"],
+    # 2F
+    ['tof 2f', 'tof 1f west', False, "ph_has_short_range(state, player)"],
+    ['tof 1f west', 'tof 1f sw', False, "ph_spiral_wall_switches(state, player)"],
+    ['tof 1f sw', 'tof 2f south', False, "ph_can_kill_bubble(state, player)"],
+    ['tof 2f south', 'tof 3f', False, "ph_tof_3f(state, player)"],
+    # 3F
+    ['tof 3f', 'tof 3f key drop', False, "ph_has_boomerang(state, player)"],
+    ['tof 3f key drop', 'tof 3f boss key', False, "any([ph_has_small_keys(state, player, 'Temple of Fire', 3),ph_ut_small_key_own_dungeon(state, player)])"],  # All 3F checks need boomerang, UT included
+    ['tof 3f boss key', 'tof blaaz', False, "all([ph_has_sword(state, player),ph_has_boss_key_simple(state, player, 'Temple of Fire')])"],  # Includes UT
+    ['tof blaaz', 'post tof', False, None],
+
+    # =========== Molida Island ===============
+
+    ['molida island', 'molida dig', False, "ph_has_shovel(state, player)"],
+    ['molida island', 'molida grapple', False, "ph_has_grapple(state, player)"],
+    ['molida island', 'molida cave back', False, "ph_has_cave_damage(state, player)"],
+    ['molida cave back', 'molida cave back dig', False, "ph_has_shovel(state, player)"],
+    ['molida cave back dig', 'molida cuccoo dig', False, "ph_has_grapple(state, player)"],
+    ['molida dig', 'molida north', False, "ph_has_sun_key(state, player)"],
+    ['molida north', 'molida north grapple', False, "ph_has_grapple(state, player)"],
+    ['molida north', 'toc', False, "ph_can_enter_toc(state, player)"],
+    ['toc crayk', 'post toc', False, None],
+    ['post toc', 'molida archery', False, None],
+
+    # =============== Temple of Courage ================
+
+    ['toc', 'toc bomb alcove', False, "ph_has_explosives(state, player)"],
+    ['toc', 'toc b1', False, "ph_toc_key_door_1(state, player)"],
+    ['toc', 'toc hammer clips', False, "ph_can_hammer_clip(state, player)"],
+    ['toc b1', 'toc b1 grapple', False, "any([ph_has_grapple(state, player),ph_can_boomerang_return(state, player)])"],
+    ['toc b1', 'toc 1f west', False, "ph_has_explosives(state, player)"],
+    ['toc b1 grapple', 'toc 1f west', False, "ph_has_bow(state, player)"],
+    ['toc hammer clips', 'toc 1f west', False, None],
+    ['toc 1f west', 'toc map room', False, "ph_has_explosives(state, player)"],
+    ['toc 1f west', 'toc 2f beamos', False, "ph_toc_key_door_2(state, player)"],
+    ['toc 1f west', 'toc b1 maze', False, "ph_has_shape_crystal(state, player, 'Temple of Courage', 'Square')"],
+    ['toc 2f beamos', 'toc b1 maze', False, "ph_is_ut(state, player)"],  # UT Crystal
+    ['toc 2f beamos', 'toc south 1f', False, "all([ph_is_ut(state, player),ph_has_bow(state, player)])"],
+    ['toc b1 grapple', 'toc b1 maze', False, None],
+    ['toc b1 maze', 'toc south 1f', False, "all([ph_has_bow(state, player),ph_has_shape_crystal(state, player, 'Temple of Courage', 'Square')])"],
+
+    ['toc south 1f', 'toc 2f spike corridor', False, "ph_has_explosives(state, player)"],
+    ['toc 2f spike corridor', 'toc 2f platforms', False, "all([ph_has_explosives(state, player),ph_has_bow(state, player)])"],
+    ['toc hammer clips', 'toc 2f spike corridor', False, None],
+    ['toc south 1f', 'toc 2f platforms', False, "ph_has_bow(state, player)"],
+    ['toc 2f spike corridor', 'toc torches', False, "ph_has_boomerang(state, player)"],
+    ['toc torches', 'toc torches chest', False, "ph_has_bow(state, player)"],
+    ['toc torches', 'toc pols 2', False, "ph_toc_final_switch_state(state, player)"],
+    ['toc pols 2', 'toc bk room', False, "ph_toc_key_door_3(state, player)"],
+    ['toc bk room', 'toc bk chest', False, "ph_has_bow(state, player)"],
+    ['toc bk room', 'toc before boss', False, "ph_has_boss_key(state, player, 'Temple of Courage')"],
+    ['toc bk chest', 'toc before boss', False, "ph_has_boss_key_simple(state, player, 'Temple of Courage')"],
+    ['toc before boss', 'toc before boss chest', False, "ph_has_explosives(state, player)"],
+    ['toc before boss', 'toc crayk', False, "ph_has_bow(state, player)"],
+
+    # ================ Spirit Island =====================
+
+    ['spirit island', 'spirit island gauntlet', False, "ph_has_grapple(state, player)"],
+    ['spirit island', 'spirit power 1', False, "ph_has_spirit_gems(state, player, 'Power', 10)"],
+    ['spirit island', 'spirit power 2', False, "ph_has_spirit_gems(state, player, 'Power', 20)"],
+    ['spirit island', 'spirit wisdom 1', False, "ph_has_spirit_gems(state, player, 'Wisdom', 10)"],
+    ['spirit island', 'spirit wisdom 2', False, "ph_has_spirit_gems(state, player, 'Wisdom', 20)"],
+    ['spirit island', 'spirit courage 1', False, "ph_has_spirit_gems(state, player, 'Courage', 10)"],
+    ['spirit island', 'spirit courage 2', False, "ph_has_spirit_gems(state, player, 'Courage', 20)"],
+
+    # ============ Ocean NW ===============
+    ['sw ocean west', 'nw ocean', False, "ph_has_sea_chart(state, player, 'NW')"],
+    ['sw ocean east', 'nw ocean', False, "ph_has_frog_n(state, player)"],
+    ['nw ocean', 'nw ocean frog n', False, "ph_has_cannon(state, player)"],
+    ['nw ocean', 'gust', False, None],
+    ['nw ocean', 'bannan', False, None],
+    ['nw ocean', 'zauz', False, None],
+    ['nw ocean', 'uncharted', False, None],
+    ['nw ocean', 'ghost ship', False, "ph_has_ghost_ship_access(state, player)"],
+    ['nw ocean', 'porl', False, None],
+    ['porl', 'porl item', False, "ph_has_sword(state, player)"],
+    ['porl', 'porl trade', False, "ph_has_heros_new_clothes(state, player)"],
+
+    # ================= Isle of Gust ====================
+
+    ['gust', 'gust combat', False, "ph_has_cave_damage(state, player)"],
+    ['gust', 'gust dig', False, "ph_has_shovel(state, player)"],
+    ['gust dig', 'tow', False, None],
+
+    # ================= Temple of Wind ====================
+
+    ['tow', 'tow b1', False, "any([ph_can_hammer_clip(state, player),ph_can_kill_bat(state, player)])"],
+    ['tow b1', 'tow b2', False, None],
+    ['tow b2', 'tow b2 dig', False, "ph_has_shovel(state, player)"],
+    ['tow b2', 'tow b2 bombs', False, "ph_has_explosives(state, player)"],
+    ['tow b2', 'tow b2 key', False, "any([ph_has_small_keys(state, player, 'Temple of Wind'),ph_wind_temple_key_ut(state, player)])"],
+    ['tow b2', 'tow bk chest', False, "ph_has_bombs(state, player)"],
+    ['tow', 'tow cyclok', False, "all([ph_has_bombs(state, player),ph_has_boss_key_simple(state, player, 'Temple of Wind')])"],
+    ['tow cyclok', 'post tow', False, None],
+
+    # ================= Bannan Island ====================
+
+    ['bannan', 'bannan grapple', False, "ph_has_grapple(state, player)"],
+    ['bannan', 'bannan dig', False, "ph_has_shovel(state, player)"],
+    ['bannan', 'bannan east', False, "ph_has_bombs(state, player)"],
+    ['bannan east', 'bannan east grapple', False, "ph_has_grapple(state, player)"],
+    ['bannan east grapple', 'bannan east grapple dig', False, "ph_has_shovel(state, player)"],
+    ['bannan east', 'bannan cannon game', False, "ph_has_cannon(state, player)"],
+    ['bannan', 'bannan scroll', False, "ph_bannan_scroll(state, player)"],
+
+    # ================= Zauz's Island ====================
+
+    ['zauz', 'zauz dig', False, "ph_has_shovel(state, player)"],
+    ['zauz', 'zauz blade', False, None],
+    ['ghost ship tetra', 'zauz crest', False, None],
+
+    # ================= Uncharted Island ====================
+
+    ['uncharted', 'uncharted dig', False, "ph_has_shovel(state, player)"],
+    ['uncharted', 'uncharted cave', False, "ph_has_sword(state, player)"],
+    ['uncharted cave', 'uncharted grapple', False, "ph_has_grapple(state, player)"],
+
+    # ================= Ghost Ship ====================
+
+    ['ghost ship', 'ghost ship barrel', False, "ph_ghost_ship_barrel(state, player)"],
+    ['ghost ship barrel', 'ghost ship b2', False, "any([ph_has_shape_crystal(state, player, 'Ghost Ship', 'Triangle'),ph_is_ut(state, player)])"],
+    ['ghost ship b2', 'ghost ship b3', False, None],
+    ['ghost ship b3', 'ghost ship cubus', False, "ph_has_sword(state, player)"],
+    ['ghost ship b2', 'ghost ship tetra', False, "ph_has_ghost_key(state, player)"],
+    ['ghost ship tetra', 'spawn pirate ambush', False, None],
+
+    # ================= SE Ocean ====================
+
+    ['sw ocean', 'se ocean', False, "all([ph_has_sea_chart(state, player, 'SE'),ph_has_sea_chart(state, player, 'SW')])"],
+    ['se ocean', 'se ocean frogs', False, "ph_has_cannon(state, player)"],
+    ['se ocean', 'goron', False, "ph_has_cannon(state, player)"],
+    ['se ocean', 'se ocean trade', False, "ph_has_kaleidoscope(state, player)"],
+    ['se ocean', 'iof', False, "ph_has_cannon(state, player)"],
+    ['se ocean', 'harrow', False, "ph_has_sword(state, player)"],
+    ['se ocean', 'ds', False, None],
+    ['se ocean', 'pirate ambush', False, "ph_beat_ghost_ship(state, player)"],
+
+    # ================= Goron Island ====================
+
+    ['goron', 'goron chus', False, "ph_goron_chus(state, player)"],
+    ['goron', 'goron grapple', False, "ph_has_grapple(state, player)"],
+    ['goron chus', 'goron quiz', False, None],
+    ['goron', 'goron north', False, None],
+    ['goron north', 'goron north bombchu', False, "ph_can_hit_bombchu_switches(state, player)"],
+    ['goron north', 'goron outside temple', False, "ph_has_explosives(state, player)"],
+    ['goron', 'goron outside temple', False, "ph_can_hammer_clip(state, player)"],
+    ['goron outside temple', 'goron north', False, "ph_has_bombs(state, player)"],
+    ['goron outside temple', 'gt', False, "ph_has_shovel(state, player)"],
+    ['gt dongo', 'goron chief 2', False, None],
+
+    # ================= Goron Temple ====================
+    ['gt', 'gt bow', False, "ph_has_bow(state, player)"],
+    ['gt', 'gt b1', False, "all([ph_has_explosives(state, player),ph_can_kill_eye_brute(state, player)])"],
+    ['gt', 'gt b2', False, "ph_can_hit_bombchu_switches(state, player)"],
+    ['gt b2', 'gt b3', False, None],
+    ['gt b2', 'gt b2 back', False, "any([ph_has_explosives(state, player),ph_has_boomerang(state, player)])"],
+    ['gt b2 back', 'gt bk chest', False, "ph_has_chus(state, player)"],
+    ['gt b2', 'gt dongo', False, "all([ph_has_chus(state, player),ph_has_boss_key_simple(state, player, 'Goron Temple')])"],
+
+    # ================= Harrow Island ====================
+
+    ['harrow', 'harrow dig', False, "ph_has_shovel(state, player)"],
+    ['harrow dig', 'harrow dig 2', False, "ph_has_sea_chart(state, player, 'NE')"],
+
+    # ================= Dee Ess Island ====================
+
+    ['ds', 'ds dig', False, "ph_has_shovel(state, player)"],
+    ['ds', 'ds combat', False, "ph_can_kill_eye_brute(state, player)"],
+    ['gt dongo', 'ds race', False, None],
+
+    # ================= Isle of Frost ====================
+
+    ['iof', 'iof grapple', False, "ph_has_grapple(state, player)"],
+    ['iof', 'iof dig', False, "ph_has_shovel(state, player)"],
+    ['iof grapple', 'iof grapple dig', False, "ph_has_shovel(state, player)"],
+    ['iof', 'iof yook', False, "ph_has_damage(state, player)"],
+    ['iof yook', 'toi', False, None],
+
+    # ================= Ice Temple ====================
+
+    ['toi', 'toi 2f', False, "any([ph_has_explosives(state, player),ph_has_boomerang(state, player)])"],
+    ['toi 2f', 'toi 3f', False, "any([ph_has_range(state, player),ph_has_bombs(state, player)])"],
+    ['toi 3f', 'toi 3f switch', False, "ph_has_explosives(state, player)"],
+    ['toi 3f switch', 'toi 3f boomerang', False, "ph_toi_3f_boomerang(state, player)"],
+    ['toi 3f boomerang', 'toi 2f miniboss', False, "ph_toi_key_door_1_ut(state, player)"],
+    ['toi 3f', 'toi 2f miniboss', False, "ph_toi_key_doors(state, player, 3, 1)"],
+    ['toi 2f miniboss', 'toi side path', False, "ph_has_grapple(state, player)"],
+    ['toi', 'toi side path', False, "all([ph_can_hammer_clip(state, player),ph_has_grapple(state, player)])"],
+    ['toi side path', 'toi b1', False, "any([ph_has_explosives(state, player),ph_has_hammer(state, player)])"],
+    ['toi b1', 'toi b1 2', False, "ph_has_explosives(state, player)"],
+    ['toi b1 2', 'toi b1 key', False, "ph_toi_key_door_2(state, player)"],
+    ['toi b1 2', 'toi b2', False, "ph_toi_b2(state, player)"],
+    ['toi b2', 'toi bk chest', False, "ph_can_hammer_clip(state, player)"],
+    ['toi b2', 'toi b2 key', False, "ph_toi_key_door_3(state, player)"],
+    ['toi b2 key', 'toi bk chest', False, None],
+    ['toi bk chest', 'toi gleeok', False, "ph_is_ut(state, player)"],
+    ['toi b2', 'toi gleeok', False, "ph_has_boss_key(state, player, 'Temple of Ice')"],
+
+    # ================= NE Ocean ====================
+
+    ['sw ocean', 'ne ocean', False, "ph_has_frog_square(state, player)"],
+    ['se ocean', 'ne ocean', False, "ph_has_sea_chart(state, player, 'NE')"],
+    ['ne ocean', 'ne ocean frog', False, "ph_has_cannon(state, player)"],
+    ['ne ocean', 'ne ocean combat', False, "ph_can_kill_blue_chu(state, player)"],
+    ['ne ocean', 'iotd', False, None],
+    ['ne ocean', 'maze', False, "ph_has_sword(state, player)"],
+    ['ne ocean', 'ruins', False, "all([ph_has_regal_necklace(state, player),ph_has_cave_damage(state, player)])"],
+    ['ne ocean', 'pirate ambush', False, "ph_beat_ghost_ship(state, player)"],
+
+    # ================= IotD ====================
+
+    ['iotd', 'iotd rupoor', False, "ph_has_bombs(state, player)"],
+    ['iotd', 'iotd dig', False, "ph_has_shovel(state, player)"],
+    ['iotd dig', 'iotd cave', False, "ph_has_bombs(state, player)"],
+
+    # ================= Isle of Ruins ====================
+
+    ['ruins', 'ruins dig', False, "ph_has_shovel(state, player)"],
+    ['ruins', 'ruins water', False, "ph_has_kings_key(state, player)"],
+    ['ruins water', 'mutoh', False, None],
+
+    # ================= Mutoh's Temple ====================
+
+    ['mutoh', 'mutoh hammer', False, "ph_has_hammer(state, player)"],
+    ['mutoh hammer', 'mutoh water', False, "ph_mutoh_water(state, player)"],
+    ['mutoh water', 'mutoh bk chest', False, "any([ph_has_small_keys(state, player, 'Mutoh's Temple', 2),ph_ut_small_key_own_dungeon(state, player)])"],
+    ['mutoh water', 'mutoh eox', False, "ph_has_boss_key(state, player, 'Mutoh's Temple')"],
+    ['mutoh bk chest', 'mutoh eox', False, "ph_is_ut(state, player)"],
+
+    # ================= Maze Island ====================
+
+    ['maze', 'maze east', False, "ph_has_explosives(state, player)"],
+    ['maze', 'maze normal', False, "ph_has_bow(state, player)"],
+    ['maze normal', 'maze expert', False, "ph_has_grapple(state, player)"],
+
+    # Goal stuff
+    ['mercay island', 'beat required dungeons', False, "ph_beat_required_dungeons(state, player)"],
+    ['sw ocean east', 'bellumbeck', False, "ph_bellumbeck_quick_finish(state, player)"],
+    ['bellumbeck', 'beat bellumbeck', False, "ph_can_beat_bellumbeck(state, player)"],
+    ['beat bellumbeck', 'goal', False, "ph_option_goal_bellum(state, player)"],
+    ['totok midway', 'goal', False, "ph_option_goal_midway(state, player)"]
+]
+
+# New format : dict of region -> dict of connection + requirements
+new_logic: dict[str, dict[str, str]] = {}
+for reg1, reg2, _, logic in overworld_logic:
+    new_logic.setdefault(reg1, {})
+    new_logic[reg1][reg2] = logic
+
+for reg1, data in new_logic.items():
+    print(f"{reg1} has exit to:")
+    for reg2, logic in data.items():
+        if logic is None:
+            print(f"\t- {reg2}")
+        else:
+            print(f"\t- {reg2}, {logic}")


### PR DESCRIPTION
## Glitches added to logic
- Ember grapple chest without grapple
- Ice temple BCL
- Mercay passage without sword
- ToC grapple chest with boomerang
- Mercay out of bounds with swordsman's scroll

## New Check
- Dee Ess Island Blow On Mic Chest

## Bugfixes
- Checks should no longer be sent on savewarps
- Goron island north spike chest is now correctly in logic
- Fixed critical client crash on oshus
- Boss rewards are now filtered out from non-local items
- sending extra swords should now correctly give sword

## Remaining issues
- Ghost ship doesn't respawn properly sometimes
- sword sometimes goes missing

## Needs further testing
- Hammer skew in mutohs?
- Open ghost ship not respawning
- Ice plateau with azurine
- Oshus checks
