### PR TITLE
Cap spirit gems to 20 when entering spirit island cave

### DIFF
--- a/worlds/tloz_ph/Client.py
+++ b/worlds/tloz_ph/Client.py
@@ -1060,6 +1060,13 @@ class PhantomHourglassClient(BizHawkClient):
                 read_addr.add(a)
                 unset_bits[a] = unset_bits.get(a, 0) | v
                 print(f"\tunsetting bit for {data['name']}")
+            for a, v in data.get("overwrite_if_true", []):
+                read_addr.add(a)
+                if type(v) is str:
+                    v = item_count(ctx, v)
+                set_bits[a] = v
+                unset_bits[a] = ~v
+                print(f"\toverwriting bit for {data['name']}")
 
             # Special full heal condition
             if "full_heal" in data:

--- a/worlds/tloz_ph/data/DynamicFlags.py
+++ b/worlds/tloz_ph/data/DynamicFlags.py
@@ -316,6 +316,34 @@ DYNAMIC_FLAGS = {
         "not_has_locations": ["Temple of Courage Crayk Dungeon Reward"],
         "unset_if_true": [(0x1B557F, 0x80)]
     },
+    # Spirit Island cap spirit gems to 20 on enter
+    "Power Gem cap": {
+        "on_scenes": [0x1701],
+        "has_items": [("Power Gem", 20)],
+        "overwrite_if_true": [(0x1BA541, 0x14)],
+        "reset_flags": ["RESET Power Gem cap"]
+    },
+    "Courage Gem cap": {
+        "on_scenes": [0x1701],
+        "has_items": [("Courage Gem", 20)],
+        "overwrite_if_true": [(0x1BA542, 0x14)],
+        "reset_flags": ["RESET Courage Gem cap"]
+    },
+    "Wisdom Gem cap": {
+        "on_scenes": [0x1701],
+        "has_items": [("Wisdom Gem", 20)],
+        "overwrite_if_true": [(0x1BA540, 0x14)],
+        "reset_flags": ["RESET Wisdom Gem cap"]
+    },
+    "RESET Power Gem cap": {
+        "overwrite_if_true": [(0x1BA541, "Power Gem")],
+    },
+    "RESET Courage Gem cap": {
+        "overwrite_if_true": [(0x1BA542, "Courage Gem")]
+    },
+    "RESET Wisdom Gem cap": {
+        "overwrite_if_true": [(0x1BA540, "Wisdom Gem")]
+    },
     # Courage Crest Room
     "Courage Crest room not salvaged it": {
         "on_scenes": [0x2508],


### PR DESCRIPTION
Added dynaflag triggers on entering spirit cave that cap spirit gems to 20 and reset to whatever number they should be on exit.

Had to tinker with the process_dynamic_flags method and add a overwrite_if_true option since set_if_true and unset_if_true were too restrictive for setting the spirit gems to specific numbers.
