### PR TITLE
tloz_ph 9.3: Key theft, map warp bug, shield locs, shop maps, boss ev…

### DIFF
--- a/worlds/tloz_ph/Client.py
+++ b/worlds/tloz_ph/Client.py
@@ -1300,7 +1300,7 @@ class PhantomHourglassClient(DSZeldaClient):
 
         if "do_special" in location:
             if location["do_special"] == "keylock":
-                print(f"Got item in Mountain passage: {ctx.items_received[-1]}")
+                # print(f"Got item in Mountain passage: {ctx.items_received[-1]}")
                 self.item_location_combo = location
             if location["do_special"] == "ut_event":
                 key = storage_key(ctx, ut_events_key)
@@ -1493,11 +1493,12 @@ class PhantomHourglassClient(DSZeldaClient):
             return _write_list
 
         # print(f"Getting item last location: {self.last_location} location_models: {ctx.slot_data.get("location_models", {})}")
-        if local_item and self.last_location and str(self.last_location['id']) in ctx.slot_data.get("location_models", {}):
+        model_id = ctx.slot_data.get("location_models", {}).get(str(self.last_location['id']), None) if self.last_location else None
+        if local_item and model_id is not None:
             # Handle locs with swapped items
             if "chest_offset" in self.last_location or "gift_addr" in self.last_location:
                 print(f"Handling Item: {item_name} ghost? {item_data.ghost_model} reset? {item_data.model_reset} last_vanilla: {self.last_vanilla_item}")
-                if (item_data.ghost_model or item_data.model is None) and self.current_scene not in getattr(item_data, "blocked_scenes", []):
+                if (item_data.ghost_model or item_data.model is None or model_id in [0x1D, 0x1E]) and self.current_scene not in getattr(item_data, "blocked_scenes", []):
                     write_list += await item_data.receive_item(self, ctx, num_received_items)
 
                 vanilla_model = item_data.vanilla_model[0]

--- a/worlds/tloz_ph/MapWarp.py
+++ b/worlds/tloz_ph/MapWarp.py
@@ -225,7 +225,7 @@ async def set_visibility(ctx: "BizHawkClientContext"):
 
 async def map_mode(client: "PhantomHourglassClient", ctx: "BizHawkClientContext", read_list):
     # Check options
-    if ctx.slot_data.get("map_warp_options", 0) == 0 and False: return
+    if ctx.slot_data.get("map_warp_options", 0) == 0: return
 
     if client.warp_to_start_flag:
         client.warp_to_start_flag = False

--- a/worlds/tloz_ph/__init__.py
+++ b/worlds/tloz_ph/__init__.py
@@ -225,11 +225,12 @@ class PhantomHourglassWorld(World):
             self.boss_reward_items_pool = slot_data["boss_reward_items_pool"]
             self.ut_pairings = slot_data.get("er_pairings", {})
             self.treasure_price_index = slot_data.get("treasure_price_index", 0)
+            required_dungeon_locations = slot_data.get("required_dungeon_locations", [])
 
             # Figure out what events are active, and add to ut_pairings
             print(F"Generating early")
             print(f"UT Pairings: {self.ut_pairings}")
-            if (self.options.ut_events and getattr(self.multiworld, "enforce_deferred_connections", "default") != "off"):
+            if self.options.ut_events and getattr(self.multiworld, "enforce_deferred_connections", "default") != "off":
                 for event in EVENTS.values():
                     if self.options.ut_events == "unique_events" and event.extra_data.get("shared_event", False):
                         continue
@@ -246,6 +247,8 @@ class PhantomHourglassWorld(World):
                     if not self.options.shuffle_overworld_transitions and event.name == "EVENT: Gust Windmills":
                         continue
                     if "Unnamed Entrance" in event.name:
+                        continue
+                    if self.options.dungeon_hint_type.value == 2 and event.name in BOSS_EVENT_TO_LOCATION and BOSS_EVENT_TO_LOCATION[event.name] not in required_dungeon_locations:
                         continue
 
                     print(f"Adding Event: {event.name} {event.id} => {event.vanilla_reciprocal.id}")
@@ -1347,8 +1350,9 @@ class PhantomHourglassWorld(World):
                 continue
             if item.game in ["Phantom Hourglass"]:
                 if ITEMS[item.name].model is not None:
-                    location_models[loc_data['id']] = ITEMS[item.name].model
-                    continue
+                    if not (item.name.startswith("Treasure Map") and loc.name in CATEGORY_LOCATION_GROUPS["Counter Shops"]):
+                        location_models[loc_data['id']] = ITEMS[item.name].model
+                        continue
 
             if item.classification & ItemClassification.progression or item.classification & ItemClassification.useful:
                 location_models[loc_data['id']] = 0x1E  # blue force gem
@@ -1483,10 +1487,15 @@ class PhantomHourglassWorld(World):
                     # print(f"Pairing {pairing} {entrance_id_to_entrance[i].name}")
                     # print(f"UT pairings {self.ut_pairings}")
                     if pairing is not None:
+                        exit_name = entrance_id_to_entrance[i].name
                         _exit: "Entrance" = self.get_entrance(entrance_id_to_entrance[i].name)
                         entrance_region: "Region" = self.get_region(entrance_id_to_region[pairing])
                         print(f"Connecting: {_exit} => {entrance_region} | {i}: {pairing}")
                         _exit.connect(entrance_region)
+
+                        if exit_name in BOSS_EVENT_TO_LOCATION:
+                            print(f"Globally connecting menu => {_exit.parent_region}")
+                            self.get_region("Menu").connect(_exit.parent_region)
 
                 self.ut_connected_entrances |= new_entrances
 
@@ -1506,6 +1515,7 @@ class PhantomHourglassWorld(World):
                     e.connected_region = None
                     # Create target
                     parent_region.create_er_target(e.name)
+
 
         if "ph_keylocking" in key and stored_data:
             print(f"Attempting to keylock stuff!")

--- a/worlds/tloz_ph/data/Constants.py
+++ b/worlds/tloz_ph/data/Constants.py
@@ -1177,6 +1177,16 @@ CATEGORY_LOCATION_GROUPS = {
         "Masked Beedle Heart Container",
         "Masked Beedle Courage Gem",
     ],
+    "Counter Shops": [
+        "Beedle Shop Bomb Bag",
+        "Beedle Shop Wisdom Gem",
+        "Masked Beedle Heart Container",
+        "Masked Beedle Courage Gem",
+        "Island Shop Power Gem",
+        "Island Shop Quiver",
+        "Island Shop Bombchu Bag",
+        "Island Shop Heart Container",
+    ],
     "Minigames": [
         "Bannan Island East Cannon Game",
         "Prince of Red Lions Combat Reward",
@@ -2065,6 +2075,12 @@ shop_location_lookup = {
     0x2a: "Island Shop Bombchu Bag",
     0xa: "Island Shop Heart Container"
 }
+
+SHOP_SCENES = [
+    0xB11,
+    0xc0e,
+
+]
 
 if __name__ == "__main__":
     for cat, value in CATEGORY_LOCATION_GROUPS.items():

--- a/worlds/tloz_ph/data/DynamicFlags.py
+++ b/worlds/tloz_ph/data/DynamicFlags.py
@@ -41,12 +41,10 @@ DYNAMIC_FLAGS = {
     },
     "Mercay yellow guy treasure map": {
         "on_scenes": [0xB03],
-        "not_has_locations": ["Mercay SE Ojibe (Docks Guy) Item"],
         "unset_if_true": [(PHAddr.treasure_maps_0, 0x02)],
         "reset_flags": ["RESET Mercay yellow guy treasure map"]
     },
     "RESET Mercay yellow guy treasure map": {
-        # "on_scenes": [0x000, 0xB00, 0xB02, 0xB0C, 0xB0D, 0xB0E, 0xB0F, 0xB11, 0x2701],
         "has_items": [("Treasure Map #9 (Cannon W)", 1)],
         "set_if_true": [(PHAddr.treasure_maps_0, 0x02)]
     },
@@ -390,12 +388,17 @@ DYNAMIC_FLAGS = {
     "Reset cc room": {
         "on_scenes": [0x2508],
         "reset_flags": ["RESET Courage Crest room not salvaged it", "RESET Courage Crest room remove crest",
-                        "RESET Courage Crest room remove crest if not got it"]
+                        "RESET Courage Crest room remove crest if not got it", "RESET Courage Crest room salvaged it"]
     },
-    "RESET Courage Crest room not salvaged it": {
+    "RESET Courage Crest room salvaged it": {
         # "on_scenes": [0x2600, 0x2507],
         "has_locations": ["Ocean SW Salvage Courage Crest"],
         "set_if_true": [(PHAddr.adv_flags_2, 0x40)]
+    },
+    "RESET Courage Crest room not salvaged it": {
+        # "on_scenes": [0x2600, 0x2507],
+        "not_has_locations": ["Ocean SW Salvage Courage Crest"],
+        "unset_if_true": [(PHAddr.adv_flags_2, 0x40)]
     },
     "RESET Courage Crest room remove crest": {
         # "on_scenes": [0x2600, 0x2507],
@@ -484,7 +487,8 @@ DYNAMIC_FLAGS = {
     # boat requires sea chart
     "Always Despawn Linebeck 1": {
         "on_scenes": [0xB03],
-        "unset_if_true": [(PHAddr.adv_flags_2, 0x8)]
+        "unset_if_true": [(PHAddr.adv_flags_2, 0x8)],
+        "set_if_true": [(PHAddr.adv_flags_3, 0x10)]
     },
     "Always Spawn linebeck 2 setting": {
         "on_scenes": [0xB03],
@@ -585,6 +589,14 @@ DYNAMIC_FLAGS = {
         "has_slot_data": [("shuffle_dungeon_entrances", 0), ("shuffle_bosses", 0)],
         "set_if_true": [(PHAddr.flags_fog_spirits, 0x10), (PHAddr.flags_fog_done, 0x10)],  # Spawn spirits, remove fog
         "unset_if_true": [(PHAddr.flags_clear_fog, 0x80)]  # Respawn ghost ship
+    },
+    "Respawn ghost ship vanilla fog": {
+        "on_scenes": [0x1],  # NW quadrant
+        "not_last_scenes": [0x2903, 0x400],  # from ghost ship
+        "not_on_entrance": [5],  # prevent respawning if coming from ghost ship
+        "not_has_locations": ["Ghost Ship Rescue Tetra"],
+        "has_slot_data": [("fog_settings", 1)],
+        "unset_if_true": [(PHAddr.flags_clear_fog, 0x80), (PHAddr.flags_fog_done, 0x10)]  # Respawn ghost ship, add fog
     },
     "Always Respawn ghost ship with dungeon rando": {
         "on_scenes": [0x1],  # NW quadrant

--- a/worlds/tloz_ph/data/Locations.py
+++ b/worlds/tloz_ph/data/Locations.py
@@ -156,6 +156,7 @@ LOCATIONS_DATA = {
         "value": 0x2,
         "vanilla_item": "Treasure Map #9 (Cannon W)",
         "id": 13,
+        "persistent": True,
         # "gift_addr": Address(0x2165FC)  # Need a better detection method for this...
     },
     "Shipyard Chest": {
@@ -234,6 +235,7 @@ LOCATIONS_DATA = {
         "stage_id": 0x27,
         "floor_id": 0x0,
         "z_max": 0x11170,
+        "y": 0,
         "sram_addr": PHSRAM.mountain_passage,
         "sram_value": 0x2,
         "dungeon": "Mountain Passage",
@@ -1708,7 +1710,8 @@ LOCATIONS_DATA = {
         "x_min": -0x1f40,
         "id": 132,
         "hint_entrance": ["Spirit Island Cave", "Spirit Board Ship"],
-        "chest_offset": 136
+        "chest_offset": 136,
+        "read_object": True,
     },
     "Spirit Island Gauntlet Chest": {
         "region_id": "Spirit Island Gauntlet",
@@ -1939,6 +1942,7 @@ LOCATIONS_DATA = {
         "stage_id": 0x1d,
         "floor_id": 0x1,
         "y": 0x0,
+        "x_max": 40000,
         "dungeon": "Temple of Wind",
         "id": 153,
         "hint_entrance": ["ToW Exit", "ToW Enter Boss"],
@@ -2542,7 +2546,8 @@ LOCATIONS_DATA = {
         "dungeon": "Goron Temple",
         "id": 199,
         "hint_entrance": ["GT Exit", "GT Enter Boss"],
-        "chest_offset": 20
+        "chest_offset": 20,
+        "read_object": True,
     },
     "Goron Temple B1 Kill Eyeslugs Chest": {
         "region_id": "GT B1",
@@ -2906,6 +2911,7 @@ LOCATIONS_DATA = {
         "floor_id": 0x1,
         "vanilla_item": "Red Potion",
         "z_max": -0x7530,
+        "x_min": 70000,
         "dungeon": "Temple of Ice",
         "id": 229,
         "hint_entrance": ["ToI Exit", "ToI Enter Boss"],
@@ -2917,6 +2923,7 @@ LOCATIONS_DATA = {
         "floor_id": 0x1,
         "vanilla_item": "Wisdom Gem",
         "y": 0x1333,
+        "x_max": -70000,
         "dungeon": "Temple of Ice",
         "id": 230,
         "hint_entrance": ["ToI Exit", "ToI Enter Boss"],
@@ -2927,7 +2934,9 @@ LOCATIONS_DATA = {
         "stage_id": 0x1f,
         "floor_id": 0x1,
         "vanilla_item": "Small Key (Temple of Ice)",
-        "y": 0x2666,
+        # "y": 0x2666,
+        "x_min": -70000,
+        "x_max": 70000,
         "dungeon": "Temple of Ice",
         "id": 231,
         "hint_entrance": ["ToI Exit", "ToI Enter Boss"],
@@ -3173,6 +3182,19 @@ LOCATIONS_DATA = {
         "z_max": -0x9c40,
         "conditional": True,
         "id": 250,
+        "delay_pickup": ["Isle of Ruins NW Like-Like Dig Shield"]
+    },
+    "Isle of Ruins NW Like-Like Dig Shield": {
+        "region_id": "Ruins NW Dig",
+        "vanilla_item": "Shield",
+        "stage_id": 0x11,
+        "floor_id": 0x1,
+        "additional_rooms": [0x1201],
+        "y": 0x1333,
+        "x_max": -0x30d40,
+        "z_max": -0x9c40,
+        "conditional": True,
+        "id": 330,
     },
     "Isle of Ruins NW Upper Bonk Tree": {
         "region_id": "Ruins NW Across Bridge",
@@ -3285,7 +3307,8 @@ LOCATIONS_DATA = {
         "dungeon": "Mutoh's Temple",
         "id": 259,
         "hint_entrance": ["MT Exit", "MT Enter Boss"],
-        "chest_offset": 56
+        "chest_offset": 56,
+        "read_object": True
     },
     "Mutoh's Temple 3F Hammer Chest": {
         "region_id": "MT Landing",
@@ -3295,7 +3318,8 @@ LOCATIONS_DATA = {
         "dungeon": "Mutoh's Temple",
         "id": 260,
         "hint_entrance": ["MT Exit", "MT Enter Boss"],
-        "chest_offset": 2
+        "chest_offset": 2,
+        "read_object": True,
     },
     "Mutoh's Temple B2 Spike Roller Chest": {
         "region_id": "MT Hammer",


### PR DESCRIPTION
- Allowed getting `ToI 3F Key Drop` location after jumping on the floor
- Adjusted some more small key drop collision boxes, that may have been stealing keys
- Map Warp is no longer active when disabled in the settings
  - this could also cause inaccessible areas to be show as in logic in UT, since successfully priming a warp adds a logical path shortcut to that destination.
- Courage Crest room properly resets salvage spot, preventing the location from being sent randomly at sea
- Linebeck will no longer make you blow the dust off the NW sea chart
- Can no longer collect Ojibe's item multiple times
- Picking up shields dropped by like-likes no longer sends the nearest location
- Fixed softlock from getting treasure maps from shops
- Fixed fog disappearing early with vanilla fog setting
- UT boss event diamonds now only show for (known) required bosses
- UT boss events now connect even when obtained out of logic
