### PR TITLE
Develop 2

### DIFF
--- a/worlds/tloz_ph/Client.py
+++ b/worlds/tloz_ph/Client.py
@@ -148,7 +148,7 @@ class PhantomHourglassClient(DSZeldaClient):
         self.stage_flag_offset = STAGE_FLAGS_OFFSET
         self.hint_data = HINT_DATA
         self.entrances = ENTRANCES
-        self.item_data = ITEMS
+        self.item_data: dict[str, "PHItem"] = ITEMS
 
         # Ph variables
         self.goal_room = 0x3600
@@ -840,20 +840,10 @@ class PhantomHourglassClient(DSZeldaClient):
         if stage in STAGE_FLAGS:
             flags = STAGE_FLAGS[stage]
 
-            # Change certain stage flags based on options
-            if stage == 0 and ctx.slot_data["skip_ocean_fights"] == 1:
-                flags = SKIP_OCEAN_FIGHTS_FLAGS
-            if stage == 41 and ctx.slot_data["logic"] >= 1:
-                flags = SPAWN_B3_REAPLING_FLAGS
-
             printl(f"\tSetting Stage flags for {STAGES[stage]}, "
                   f"adr: {self.stage_flag_address}")
             await self.stage_flag_address.set_bits(ctx, flags)
 
-        # # Unlock boss door if have bk
-        # data = BOSS_DOOR_DATA.get(stage, False)
-        # if data and ctx.slot_data.get("boss_key_behaviour", True) and self.item_count(ctx, f"Boss Key ({data['name']})"):
-        #     await data["address"].set_bits(ctx, data["value"])
 
     async def open_boss_door(self, ctx):
         data = BOSS_DOOR_DATA.get(self.current_scene, False)
@@ -1198,7 +1188,7 @@ class PhantomHourglassClient(DSZeldaClient):
         else:
             self.sent_event = True
 
-    async def conditional_er(self, ctx, exit_data, silent=False) -> bool:
+    async def conditional_er(self, ctx, exit_data, silent=False, detect_data=None) -> bool:
         printl(f"\tcond. {exit_data.name} {exit_data.extra_data} lowered water: {self.lowered_water}")
         if "conditional" in exit_data.extra_data:
             # Bounce back if the entrance connects to a lower room
@@ -1568,10 +1558,10 @@ class PhantomHourglassClient(DSZeldaClient):
 
     @staticmethod
     async def find_table_object(ctx: "BizHawkClientContext", start_offset: int,
-                              check_offset, comp_value: int | list,
+                              check_offset: int, comp_value: int | list,
                               size=4,
                               table_addr: Address=PHAddr.map_obj_table,
-                              return_index=False, max_search: int=35) -> Address | tuple[Address, int] | None:
+                              return_index: bool=False, max_search: int=35, reverse: bool=True) -> Address | tuple[Address, int] | None:
         """
         Find a specific object from a pointer table.
         Loops backwards from start_offset until the validation check matches.
@@ -1583,6 +1573,7 @@ class PhantomHourglassClient(DSZeldaClient):
         :param size: size of the comp value read
         :param return_index: return the table index that the correct object was found at along with the object data address
         :param max_search: How far to search. -1 checks the entire table
+        :param reverse: Start backwards for efficiency
         :return: Address of valid object, or tuple of Address and table index
         """
         async def check_multi(l) -> tuple[Address | None, int]:
@@ -1655,6 +1646,75 @@ class PhantomHourglassClient(DSZeldaClient):
 
         await bizhawk.write(ctx.bizhawk_ctx, write_list)
 
+    @staticmethod
+    async def load_map_object_table(ctx):
+        pointer = await PHAddr.gMapObjectManager.read(ctx)
+        reads = await read_multiple(ctx, [Address.from_pointer(pointer, size=3), Address.from_pointer(pointer+4, size=3)])
+        start, last = list(reads.values())
+        PHAddr.map_object_table.set_addr(start)
+        size = (last-start)//4
+        print(f"Start, last: {hex_f(start)}, {hex_f(last)} = {size}")
+
+        return size
+
+    async def process_map_objects(self, ctx):
+        whitelisted_stages = list(range(0x18, 0x1e)) + list(range(0x30, 0x35)) + [0x13, 0x2D, 0x2E, 0x37, 0x3E, 0x3F, 0x41, 0x42] + list(range(0x45, 0x4B))
+        if self.current_stage not in whitelisted_stages:
+            return
+
+        table_size = await self.load_map_object_table(ctx)
+        actor_idents = await self.get_table_data(ctx, STAddr.map_object_table, 0,
+                                                 size=3, table_label=False, table_size=table_size)
+        printl(f"map objects: {hex_f(actor_idents)}")
+
+        identifiers = map_object_identifiers
+
+        write_list = []
+        for addr, i in actor_idents.items():
+            if addr == 0x5544:
+                printl("Map Object Overflow!")
+                break
+            if i not in identifiers:
+                printl(f"Unknown map object: {hex_f(i)} @ {addr}")
+                continue
+
+            if identifiers.get(i) in ["Blue Door", "Key Door", "Arena Door", "Bell Door", "Gem Door"]:
+                write_list.append(Address.from_pointer(addr + 33*4 + 2, size=1).get_inner_write_list(0))  # closing
+                write_list.append(Address.from_pointer(addr + 34*4 + 2, size=1).get_inner_write_list(0))  # opening
+
+                if identifiers.get(i) == "Key Door":
+                    self.key_door_watches.append(Address.from_pointer(addr + 22, 1))
+
+                # if self.current_scene == 0x4206 and all([LOCATIONS_DATA[l]['id'] in ctx.checked_locations for l in [
+                #         "Lost at Sea Final Challenge SE Chest", "Lost at Sea Final Challenge NE Chest",
+                #         "Lost at Sea Final Challenge SW Chest", "Lost at Sea Final Challenge NW Chest"
+                #     ]]):
+                #         write_list.append(Address.from_pointer(addr + 22).get_inner_write_list(3))
+
+            if identifiers.get(i) in ["Bridge"]:
+                write_list.append(Address.from_pointer(addr+24*4, size=2).get_inner_write_list(0))
+
+            if identifiers.get(i) in ["Switch"]:
+                write_list.append(Address.from_pointer(addr+9*4 + 2, size=1).get_inner_write_list(0))
+
+            if identifiers.get(i) in ["Spikes"]:
+                write_list.append(Address.from_pointer(addr+19*4+3, size=1).get_inner_write_list(0))
+
+            if identifiers.get(i) in ["Boss Door"]:
+                await self.open_boss_door(ctx, addr)
+                self.boss_door_addr = addr
+
+            if identifiers.get(i) in ["Torch"]:
+                write_list.append(Address.from_pointer(addr+33*4 + 2, size=1).get_inner_write_list(0))
+
+            # if identifiers.get(i) in ["Flames"]:
+            #     write_list.append(Address.from_pointer(addr + 33 * 4 + 2, size=1).get_inner_write_list(0))
+
+        if write_list:
+            printl(f"Deleting Cutscenes: {hex_f(write_list)}")
+            await bizhawk.write(ctx.bizhawk_ctx, write_list)
+
+
     async def get_object_read_addr(self, ctx, location) -> Address | None:
         vanilla_item_model = self.item_data[location["vanilla_item"]].vanilla_model
         chest_object = await self.find_table_object(ctx, location["chest_offset"], 9, vanilla_item_model, size=1)
@@ -1671,10 +1731,11 @@ class PhantomHourglassClient(DSZeldaClient):
         printl(f"Setting vanilla item for {location.get('name')}")
         if "chest_offset" in location or "gift_addr" in location:
             model = ctx.slot_data.get("location_models", {}).get(str(location["id"]), 0x1E)
-            printl(f"Got swapped item model as vanilla item {hex(model)}: {model_resets.get(model)} {model_reset_vanillas.get(model)}")
+            printl(f"Got swapped item model as vanilla item {hex(model)}: {model_resets.get(model)} {model_reset_vanillas.get(model)} {vanilla_item}")
             # Always remove for previously checked locations
-            if model_resets.get(model):
+            if model_resets.get(model, ""):
                 printl(f"\tResetting model: {model_resets[model]}")
+                self.delay_reset += 1  # Add delay reset to make sure removal handling runs properly
                 await super()._set_vanilla_item(ctx, location, model_resets.get(model))
             return
         await super()._set_vanilla_item(ctx, location, vanilla_item)
@@ -1725,12 +1786,12 @@ class PhantomHourglassClient(DSZeldaClient):
         spot_data = dig_spot_data_water if self.current_stage == 0x12 else dig_spot_data
 
         async def scan_actor_table() -> list[int]:
-            _read_list = [Address.from_pointer(self.actor_table_pointer+3+4*i) for i in range(scan_len)]
+            _read_list = [Address.from_pointer(self.actor_table_pointer+3+4*j) for j in range(scan_len)]
             _read_list += [spot_data[_loc].item_pointer_addr for _loc in self.dig_spots_in_scene if spot_data[_loc].is_tree]
             res = await read_multiple(ctx, _read_list)
             return list(res.values())
 
-        def get_first_new_actor(d) -> int:
+        def get_first_new_actor(d) -> int or None:
             for k, v in d.items():
                 if v == 2:
                     return k

--- a/worlds/tloz_ph/Client.py
+++ b/worlds/tloz_ph/Client.py
@@ -212,6 +212,7 @@ class PhantomHourglassClient(DSZeldaClient):
         self.actor_table_pointer: Address | None = None
         self.last_actor_scan: list[int] = []
         self.linked_dig_spots: dict[str, int] = {}
+        self.key_door_watches: list["Address"] = []
 
 
     async def check_game_version(self, ctx: "BizHawkClientContext") -> bool:
@@ -425,6 +426,18 @@ class PhantomHourglassClient(DSZeldaClient):
         if self.current_stage == 3 and read_result.get(PHAddr.salvage_health, 5) <= 1:
             await self.instant_repair_salvage_arm(ctx)
 
+        # Prevent key door cs skips from opening too slow and closing again
+        if self.key_door_watches:
+            reads = await read_multiple(ctx, self.key_door_watches)
+            for a, v in reads.items():
+                if 8 > v > 2:
+
+                    await write_multiple(ctx, [a, Address.from_pointer(a+28*4+2, 1)], [7, 0xff])
+                    self.key_door_watches.remove(a)
+                    break
+                if v == 8:
+                    self.key_door_watches.remove(a)
+
         # Map warp entrypoint
         if read_result.get(PHAddr.in_map, 0):
             await map_mode(self, ctx, read_result)
@@ -574,6 +587,7 @@ class PhantomHourglassClient(DSZeldaClient):
         self.save_spam_protection = False  # Reset save spam protection
 
         await self.set_chest_contents(ctx)
+        await self.process_map_objects(ctx)
 
         # Yellow warp in TotOK saves keys
         # TODO: allow this to work with ER
@@ -1422,34 +1436,7 @@ class PhantomHourglassClient(DSZeldaClient):
         obj_z = await read_multiple(ctx, pointer_table, offset=4 * 8, keys=range(length), signed=True)
         item = await read_multiple(ctx, pointer_table, offset=4 * 9, keys=range(length))
 
-        typ_lookup = {
-            1: "Unspawned",
-            0x5: "House Entrance",
-            0x2D: "Closed Chest",
-            0x29: "Open Chest",
-            0x819: "Door",
-            0x9: "Solid",
-            0x6F: "Throwable",
-            0xD: "Readable or Entrance",
-            0xF: "Barrel in Cave",
-            0x19: "House",
-            0x49: "Grass",
-            0x80D: "Cave Exit",
-            0x44D: "Switch",
-            0x801: "Buried Laser Statue",
-            0x809: "Staircase",
-            0x81D: "Tap Door, lit Laser Statue",
-            0x4D: "Hammer Switch",
-            0xC1D: "Unlit Laser Statue",
-            0x4F: "Bomb Flower",
-            0x20D: "Updraft",
-            0x209: "Dirt Pile",
-            0x429: "Lit Torch",
-            0x11d: "Pedestal",
-            0x40d: "Repeater"
-        }
-
-        typ_index = {v: i+1 for i, v in enumerate(typ_lookup)}
+        typ_index = {v: i+1 for i, v in enumerate(map_object_idents)}
 
         @dataclass
         class MapObject:
@@ -1462,7 +1449,7 @@ class PhantomHourglassClient(DSZeldaClient):
             addr: Address
 
             def __post_init__(self):
-                self.type_str = typ_lookup.get(self.typ, hex(self.typ))
+                self.type_str = map_object_idents.get(self.typ, hex(self.typ))
 
             def __str__(self):
                 return f"\t{self.index}\t{self.type_str} ({self.x}, {self.y}, {self.z}) {hex(self.item)} {self.addr}"
@@ -1646,28 +1633,14 @@ class PhantomHourglassClient(DSZeldaClient):
 
         await bizhawk.write(ctx.bizhawk_ctx, write_list)
 
-    @staticmethod
-    async def load_map_object_table(ctx):
-        pointer = await PHAddr.gMapObjectManager.read(ctx)
-        reads = await read_multiple(ctx, [Address.from_pointer(pointer, size=3), Address.from_pointer(pointer+4, size=3)])
-        start, last = list(reads.values())
-        PHAddr.map_object_table.set_addr(start)
-        size = (last-start)//4
-        print(f"Start, last: {hex_f(start)}, {hex_f(last)} = {size}")
-
-        return size
-
     async def process_map_objects(self, ctx):
-        whitelisted_stages = list(range(0x18, 0x1e)) + list(range(0x30, 0x35)) + [0x13, 0x2D, 0x2E, 0x37, 0x3E, 0x3F, 0x41, 0x42] + list(range(0x45, 0x4B))
-        if self.current_stage not in whitelisted_stages:
-            return
 
-        table_size = await self.load_map_object_table(ctx)
-        actor_idents = await self.get_table_data(ctx, STAddr.map_object_table, 0,
+        table_size = await PHAddr.map_obj_table_size.read(ctx)
+        actor_idents = await self.get_table_data(ctx, PHAddr.map_obj_table, 0,
                                                  size=3, table_label=False, table_size=table_size)
         printl(f"map objects: {hex_f(actor_idents)}")
 
-        identifiers = map_object_identifiers
+        identifiers = idents_0
 
         write_list = []
         for addr, i in actor_idents.items():
@@ -1678,37 +1651,18 @@ class PhantomHourglassClient(DSZeldaClient):
                 printl(f"Unknown map object: {hex_f(i)} @ {addr}")
                 continue
 
-            if identifiers.get(i) in ["Blue Door", "Key Door", "Arena Door", "Bell Door", "Gem Door"]:
-                write_list.append(Address.from_pointer(addr + 33*4 + 2, size=1).get_inner_write_list(0))  # closing
-                write_list.append(Address.from_pointer(addr + 34*4 + 2, size=1).get_inner_write_list(0))  # opening
+            if identifiers.get(i) in ["Spirit Door", "Key Door", "Blue Door"]:
+                write_list.append(Address.from_pointer(addr + 31*4, size=4).get_inner_write_list(0))  # closing
 
-                if identifiers.get(i) == "Key Door":
-                    self.key_door_watches.append(Address.from_pointer(addr + 22, 1))
-
-                # if self.current_scene == 0x4206 and all([LOCATIONS_DATA[l]['id'] in ctx.checked_locations for l in [
-                #         "Lost at Sea Final Challenge SE Chest", "Lost at Sea Final Challenge NE Chest",
-                #         "Lost at Sea Final Challenge SW Chest", "Lost at Sea Final Challenge NW Chest"
-                #     ]]):
-                #         write_list.append(Address.from_pointer(addr + 22).get_inner_write_list(3))
-
-            if identifiers.get(i) in ["Bridge"]:
-                write_list.append(Address.from_pointer(addr+24*4, size=2).get_inner_write_list(0))
-
-            if identifiers.get(i) in ["Switch"]:
-                write_list.append(Address.from_pointer(addr+9*4 + 2, size=1).get_inner_write_list(0))
+                if identifiers.get(i) in ["Spirit Door", "Key Door"]:
+                    self.key_door_watches.append(Address.from_pointer(addr + 8, 1))
 
             if identifiers.get(i) in ["Spikes"]:
-                write_list.append(Address.from_pointer(addr+19*4+3, size=1).get_inner_write_list(0))
+                write_list.append(Address.from_pointer(addr + 30 * 4, size=2).get_inner_write_list(0))
 
-            if identifiers.get(i) in ["Boss Door"]:
-                await self.open_boss_door(ctx, addr)
-                self.boss_door_addr = addr
-
-            if identifiers.get(i) in ["Torch"]:
-                write_list.append(Address.from_pointer(addr+33*4 + 2, size=1).get_inner_write_list(0))
-
-            # if identifiers.get(i) in ["Flames"]:
-            #     write_list.append(Address.from_pointer(addr + 33 * 4 + 2, size=1).get_inner_write_list(0))
+            # if identifiers.get(i) in ["Boss Door"]:
+            #     await self.open_boss_door(ctx, addr)
+            #     self.boss_door_addr = addr
 
         if write_list:
             printl(f"Deleting Cutscenes: {hex_f(write_list)}")

--- a/worlds/tloz_ph/Client.py
+++ b/worlds/tloz_ph/Client.py
@@ -881,6 +881,8 @@ class PhantomHourglassClient(DSZeldaClient):
 
     async def update_special_key_count(self, ctx, current_stage: int, new_keys, key_data: dict, key_values, key_address: "Address") -> tuple[int, bool]:
         if current_stage == 0x25:
+            if self._just_entered_game:
+                return await key_address.read(ctx), False
             if self.location_name_to_id["TotOK 1F Sea Chart Chest"] in ctx.checked_locations:
                 new_keys -= 1  # Opening the SW sea chart door uses a key permanently! No savescums!
             if self.current_scene == 0x2504:  # Set B3.5 key count
@@ -893,7 +895,8 @@ class PhantomHourglassClient(DSZeldaClient):
         return new_keys, True
 
     async def get_small_key_address(self, ctx) -> "Address":
-        return await get_address_from_heap(ctx, PHAddr.gMapManager, SMALL_KEY_OFFSET)
+        self.key_address = await get_address_from_heap(ctx, PHAddr.gMapManager, SMALL_KEY_OFFSET)
+        return self.key_address
 
     # Called during location processing to determine what vanilla item to remove
     async def unset_special_vanilla_items(self, ctx, location, item):
@@ -1635,30 +1638,34 @@ class PhantomHourglassClient(DSZeldaClient):
 
     async def process_map_objects(self, ctx):
 
-        table_size = await PHAddr.map_obj_table_size.read(ctx)
+        table_size = await PHAddr.map_obj_table_size.read(ctx)*4
         actor_idents = await self.get_table_data(ctx, PHAddr.map_obj_table, 0,
                                                  size=3, table_label=False, table_size=table_size)
-        printl(f"map objects: {hex_f(actor_idents)}")
+        printl(f"map objects ({table_size}): {hex_f(actor_idents)}")
 
         identifiers = idents_0
 
         write_list = []
-        for addr, i in actor_idents.items():
+        for i, pack in enumerate(actor_idents.items()):
+            addr, ident = pack
             if addr == 0x5544:
                 printl("Map Object Overflow!")
                 break
-            if i not in identifiers:
-                printl(f"Unknown map object: {hex_f(i)} @ {addr}")
+            if ident not in identifiers:
+                printl(f"Unknown map object: {hex_f(ident)} @ {addr} #{i}")
                 continue
 
-            if identifiers.get(i) in ["Spirit Door", "Key Door", "Blue Door"]:
+            if identifiers.get(ident) in ["Spirit Door", "Key Door", "Blue Door", "Arena Door"]:
                 write_list.append(Address.from_pointer(addr + 31*4, size=4).get_inner_write_list(0))  # closing
 
-                if identifiers.get(i) in ["Spirit Door", "Key Door"]:
+                if identifiers.get(ident) in ["Spirit Door", "Key Door"]:
                     self.key_door_watches.append(Address.from_pointer(addr + 8, 1))
 
-            if identifiers.get(i) in ["Spikes"]:
+            if identifiers.get(ident) in ["Spikes"]:
                 write_list.append(Address.from_pointer(addr + 30 * 4, size=2).get_inner_write_list(0))
+
+            if identifiers.get(ident) in ["Bridge Spawner"]:
+                write_list.append(Address.from_pointer(addr + 15 * 4, size=2).get_inner_write_list(0))
 
             # if identifiers.get(i) in ["Boss Door"]:
             #     await self.open_boss_door(ctx, addr)

--- a/worlds/tloz_ph/Client.py
+++ b/worlds/tloz_ph/Client.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from random import randint
 
 from .DSZeldaClient.DSZeldaClient import *
-from .DSZeldaClient.subclasses import (get_address_from_heap, storage_key, get_stored_data, AddrFromPointer)
+from .DSZeldaClient.subclasses import (get_address_from_heap, storage_key, get_stored_data)
 from .data.Items import ITEMS, ITEM_GROUPS
 from .MapWarp import map_mode
 from .data.Entrances import entrance_id_to_entrance
@@ -296,7 +296,7 @@ class PhantomHourglassClient(DSZeldaClient):
         # printl(f"Treasure Tracker! {split_bits(self.last_treasures, 8)}")
 
     async def give_random_treasure(self, ctx):
-        address = AddrFromPointer(PHAddr.pink_coral_count + randint(0, 7))
+        address = Address.from_pointer(PHAddr.pink_coral_count + randint(0, 7))
         await address.add(ctx, 1)
         await self.update_treasure_tracker(ctx)
         logger.info(f"Got random treasure from farmable location.")
@@ -335,7 +335,7 @@ class PhantomHourglassClient(DSZeldaClient):
             if death_link_pointer:
                 addr, offset = death_link_pointer
                 pointer_1 = await addr.read(ctx)
-                self.health_address = AddrFromPointer(pointer_1 + offset - 0x2000000, size=2, name="link_health")
+                self.health_address = Address.from_pointer(pointer_1 + offset - 0x2000000, size=2, name="link_health")
                 self.last_health_pointer = pointer_1
                 read_keys.append(self.health_address)
             printl(f"Health Address = {self.health_address}")
@@ -382,7 +382,7 @@ class PhantomHourglassClient(DSZeldaClient):
             total = ctx.slot_data["metal_hunt_total"]
             required = ctx.slot_data["metal_hunt_required"]
         else:
-            return True
+            return
 
         if scene == 0xB0A:
             # Oshus Text
@@ -836,7 +836,7 @@ class PhantomHourglassClient(DSZeldaClient):
     async def set_stage_flags(self, ctx, stage):
         printl(f"Setting stage flags")
         self.stage_flag_address = await get_address_from_heap(ctx, PHAddr.gMapManager, STAGE_FLAGS_OFFSET)
-        self.key_address = AddrFromPointer(self.stage_flag_address + SMALL_KEY_OFFSET)
+        self.key_address = Address.from_pointer(self.stage_flag_address + SMALL_KEY_OFFSET)
         if stage in STAGE_FLAGS:
             flags = STAGE_FLAGS[stage]
 
@@ -958,8 +958,9 @@ class PhantomHourglassClient(DSZeldaClient):
                 await self.scout_location(ctx, item_data.hint_on_receive)
         # Increment metal count
         if item_name in ITEM_GROUPS["Metals"]:
-            self.metal_count += 1
-            await self.process_game_completion(ctx)
+            printl(f"Old thingy metal count: {self.metal_count+1}")
+            self.update_metal_count(ctx)
+            printl(f"Updated metal count: {self.metal_count}")
         if "Boss Key" in item_name:
             await self.open_boss_door(ctx)
 
@@ -1030,12 +1031,12 @@ class PhantomHourglassClient(DSZeldaClient):
 
     @staticmethod
     async def enable_items(ctx: "BizHawkClientContext", inventory_id: int):
-        equipped_item_pointer = AddrFromPointer(await PHAddr.gItemManager.read(ctx)-0x02000000, size=4)
+        equipped_item_pointer = Address.from_pointer(await PHAddr.gItemManager.read(ctx), size=4)
         equipped_item = await equipped_item_pointer.read(ctx, silent=True)
         if equipped_item == 0xffffffff:
             printl(f"Items menu not visible, enabling: {hex(equipped_item_pointer + EQUIP_TIMER_OFFSET)}")
             # Enable items menu
-            equipped_item_timer = AddrFromPointer(equipped_item_pointer + EQUIP_TIMER_OFFSET, size=2)
+            equipped_item_timer = Address.from_pointer(equipped_item_pointer + EQUIP_TIMER_OFFSET, size=2)
             await equipped_item_timer.overwrite(ctx, 20)
             await equipped_item_pointer.overwrite(ctx, inventory_id)
 
@@ -1055,6 +1056,7 @@ class PhantomHourglassClient(DSZeldaClient):
         if ctx.slot_data["bellum_access"] == 4:
             game_clear = self.metal_count >= ctx.slot_data["required_metals"]
             if game_clear and not self.sent_goal:
+                printl(f"Bellum access: {ctx.slot_data['bellum_access']} metal count {self.metal_count} >= {ctx.slot_data['required_metals']}")
                 await self.store_visited_entrances(ctx, ENTRANCES["GOAL"], ENTRANCES["GOAL"].vanilla_reciprocal)
                 self.sent_goal = True
         else:
@@ -1169,7 +1171,7 @@ class PhantomHourglassClient(DSZeldaClient):
                 data = [data] if isinstance(data, dict) else data
                 self.event_data = data
                 for i, event in enumerate(data):
-                    address = AddrFromPointer(self.stage_flag_address + event.get("offset", 0), size=event.get("size", 1)) if event["address"] == "stage_flags" else event["address"]
+                    address = Address.from_pointer(self.stage_flag_address + event.get("offset", 0), size=event.get("size", 1)) if event["address"] == "stage_flags" else event["address"]
                     printl(f"event data {self.event_data}")
                     self.event_data[i]["address"] = address
                     printl(f"event data {self.event_data}")

--- a/worlds/tloz_ph/Client.py
+++ b/worlds/tloz_ph/Client.py
@@ -215,6 +215,7 @@ class PhantomHourglassClient(DSZeldaClient):
         self.linked_dig_spots: dict[str, int] = {}
         self.key_door_watches: list["Address"] = []
         self.paired_object_watches: dict[str, "PairedObjects"] = {}
+        self.boss_door_addr: Address | None = None
 
 
     async def check_game_version(self, ctx: "BizHawkClientContext") -> bool:
@@ -442,13 +443,13 @@ class PhantomHourglassClient(DSZeldaClient):
             reads = await read_multiple(ctx, [obj.trigger for obj in self.paired_object_watches.values()])
             writes = []
             for read, obj in zip(reads.values(), self.paired_object_watches.copy().values()):
-                if read == obj.comp:
-                    printl(f"Paired object activated: {obj}")
-                    writes += obj.get_writes()
-                    self.paired_object_watches.pop(obj.name)
+                if obj.compare(read):
+                    if not hasattr(obj, "trigger_2") or obj.compare(await obj.trigger_2.read(ctx)):
+                        printl(f"Paired object activated: {obj}")
+                        writes += obj.get_writes()
+                        self.paired_object_watches.pop(obj.name)
             if writes:
                 await bizhawk.write(ctx.bizhawk_ctx, writes)
-
 
         # Map warp entrypoint
         if read_result.get(PHAddr.in_map, 0):
@@ -638,7 +639,7 @@ class PhantomHourglassClient(DSZeldaClient):
             await self.force_spawn_swordfish(ctx)
 
         # Open boss door
-        await self.open_boss_door(ctx)
+        # await self.open_boss_door(ctx)
 
         # Find potential dig spots
         await self.load_dig_spots(ctx)
@@ -785,10 +786,12 @@ class PhantomHourglassClient(DSZeldaClient):
     async def open_boss_door(self, ctx):
         data = BOSS_DOOR_DATA.get(self.current_scene, False)
         if data and ctx.slot_data.get("boss_key_behaviour", True) and self.item_count(ctx, f"Boss Key ({data['name']})"):
-            boss_door = await self.find_table_object(ctx, *data["map_obj_comp"])
-            if not boss_door:
-                return
-            open_state = Address.from_pointer(boss_door+2*4)
+            if not self.boss_door_addr:
+                boss_door = await self.find_table_object(ctx, *data["map_obj_comp"])
+                if not boss_door:
+                    return
+                self.boss_door_addr = boss_door
+            open_state = Address.from_pointer(self.boss_door_addr+2*4)
             if await open_state.read(ctx) == 0:
                 await open_state.overwrite(ctx, 3)
 
@@ -1472,6 +1475,7 @@ class PhantomHourglassClient(DSZeldaClient):
     async def detected_new_scene(self, ctx: "BizHawkClientContext"):
         self.key_door_watches.clear()
         self.paired_object_watches.clear()
+        self.boss_door_addr = None
 
     @staticmethod
     async def find_table_object(ctx: "BizHawkClientContext", start_offset: int,
@@ -1572,6 +1576,14 @@ class PhantomHourglassClient(DSZeldaClient):
 
         identifiers = idents_0
 
+        def add_detection(name, a, **kwargs):
+            self.paired_object_watches.setdefault(name, PairedObjects(name)).set_detection(
+                Address.from_pointer(a), **kwargs)
+
+        def add_action(name, a):
+            self.paired_object_watches.setdefault(name, PairedObjects(name)).to_activate.append(
+                Address.from_pointer(a))
+
         write_list = []
         for i, pack in enumerate(actor_idents.items()):
             addr, ident = pack
@@ -1583,7 +1595,7 @@ class PhantomHourglassClient(DSZeldaClient):
                 continue
 
             if identifiers.get(ident) in ["Spirit Door", "Key Door", "Blue Door", "Arena Door"]:
-                write_list.append(Address.from_pointer(addr + 31*4, size=4).get_inner_write_list(0))  # closing
+                write_list.append(Address.from_pointer(addr + 31*4, size=2).get_inner_write_list(0))  # closing
 
                 if identifiers.get(ident) in ["Spirit Door", "Key Door"]:
                     self.key_door_watches.append(Address.from_pointer(addr + 8, 1))
@@ -1597,7 +1609,11 @@ class PhantomHourglassClient(DSZeldaClient):
             if identifiers.get(ident) in ["Torch"]:
                 write_list.append(Address.from_pointer(addr + 38 * 4 +2, size=2).get_inner_write_list(0))
                 if self.current_scene == 0x2501 and await Address.from_pointer(addr+6*4, size=4).read(ctx, signed=True) == -10240:
-                    self.paired_object_watches.setdefault("b1_flames", PairedObjects("b1_flames")).trigger = Address.from_pointer(addr+8)
+                    add_detection("b1_flames", addr+8)
+                if (self.current_scene == 0x1c02
+                        and await Address.from_pointer(addr + 8 * 4, size=4).read(ctx, signed=True) < -45000
+                        and await Address.from_pointer(addr + 6 * 4, size=4).read(ctx, signed=True) > -60000):
+                    add_detection("tof_3f_torches", addr+8)
 
             if identifiers.get(ident) in ["Unspawned Big Chest", "Unspawned Small Chest"]:
                 write_list.append(Address.from_pointer(addr + 28 * 4, size=2).get_inner_write_list(0))
@@ -1606,26 +1622,91 @@ class PhantomHourglassClient(DSZeldaClient):
                 write_list.append(Address.from_pointer(addr + 42 * 4, size=4).get_inner_write_list(0))
 
                 if self.current_scene == 0x2501:
-                    self.paired_object_watches.setdefault("b1_flames", PairedObjects("b1_flames")).to_activate.append(Address.from_pointer(addr+8))
+                    add_action("b1_flames", addr + 8)
 
                 elif self.current_scene == 0x2502:
                     if await Address.from_pointer(addr+8*4, size=4).read(ctx, signed=True) == -6144:
-                        self.paired_object_watches.setdefault("b2_lever", PairedObjects("b2_lever")).to_activate.append(Address.from_pointer(addr+8))
+                        add_action("b2_lever", addr + 8)
                     else:
-                        self.paired_object_watches.setdefault("b2_switch", PairedObjects("b2_switch")).to_activate.append(Address.from_pointer(addr + 8))
+                        add_action("b2_switch", addr + 8)
+
+                elif self.current_scene == 0x2503:
+                    if await Address.from_pointer(addr + 8 * 4, size=4).read(ctx, signed=True) == -14336:
+                        write_list.pop()  # Phantom Flames actually use the cutscene flag
+                        write_list.append(Address.from_pointer(addr + 42 * 4+2, size=2).get_inner_write_list(0))
+                    else:
+                        add_action("b3_lever", addr + 8)
+
+                elif self.current_scene == 0x250A:
+                    if await Address.from_pointer(addr + 8 * 4, size=4).read(ctx, signed=True) == -10240:
+                        add_action("b7_chest", addr + 8)
+                    else:
+                        write_list.pop()  # Phantom Flames actually use the cutscene flag
+                        write_list.append(Address.from_pointer(addr + 42 * 4 + 2, size=2).get_inner_write_list(0))
+                elif self.current_scene in [0x2510, 0x2511]:
+                    write_list.pop()  # Phantom Flames actually use the cutscene flag
+                    write_list.append(Address.from_pointer(addr + 42 * 4 + 2, size=2).get_inner_write_list(0))
+
+                elif self.current_scene == 0x1C00:
+                    coords = await read_multiple(ctx, [Address.from_pointer(addr + 6 * 4, size=4), Address.from_pointer(addr + 8 * 4, size=4)], signed=True)
+                    x, z = list(coords.values())
+                    if x == -22528:
+                        add_action("tof_1f", addr + 8)
+                    elif z == 47104 and x > 20000:
+                        add_action("tof_arena", addr + 8)
+
+                elif self.current_scene == 0x1c01:
+                    x = await Address.from_pointer(addr + 6 * 4, size=4).read(ctx, signed=True)
+                    if x == 14336:
+                        add_action("tof_2f_e", addr + 8)
+                    elif x == -26624:
+                        add_action("tof_2f_w", addr + 8)
+
+                if self.current_scene == 0x1C02:
+                    coords = await read_multiple(ctx, [Address.from_pointer(addr + 6 * 4, size=4), Address.from_pointer(addr + 8 * 4, size=4)], signed=True)
+                    x, z = list(coords.values())
+                    if x < -20000:
+                        write_list.pop()
+                    elif x > 40000:
+                        add_action("tof_3f_candles", addr + 8)
+                    else:
+                        add_action("tof_3f_torches", addr + 8)
 
             if identifiers.get(ident) in ["Lever"]:
                 if self.current_scene == 0x2502:
-                    self.paired_object_watches.setdefault("b2_lever", PairedObjects("b2_lever")).set_detection(Address.from_pointer(addr + 8), 3)
+                    add_detection("b2_lever", addr + 8, comp=3)
+                elif self.current_scene == 0x2503:
+                    add_detection("b3_lever", addr + 8, comp=3)
 
             if identifiers.get(ident) in ["Switch"]:
                 if self.current_scene == 0x2502 and await Address.from_pointer(addr+6*4, size=4).read(ctx, signed=True) == -55296:
-                    self.paired_object_watches.setdefault("b2_switch", PairedObjects("b2_switch")).set_detection(Address.from_pointer(addr + 8), 1)
+                    add_detection("b2_switch", addr + 8, comp=1)
+
+                if self.current_scene == 0x1C00 and await Address.from_pointer(addr+8*4, size=4).read(ctx, signed=True) == -10240:
+                    add_detection("tof_1f", addr + 8, comp=1)
+
+                if self.current_scene == 0x1C01:
+                    x = await Address.from_pointer(addr+6*4, size=4).read(ctx, signed=True)
+                    if x == 63488:
+                        add_detection("tof_2f_e", addr + 8, comp=1)
+                    elif x == -63488:
+                        add_detection("tof_2f_w", addr + 8, comp=1)
 
 
-            # if identifiers.get(i) in ["Boss Door"]:
-            #     await self.open_boss_door(ctx, addr)
-            #     self.boss_door_addr = addr
+            if identifiers.get(ident) in ["Small Chest"]:
+                if self.current_scene == 0x250A:
+                    add_detection("b7_chest", addr + 8, comp=8)
+
+            if identifiers.get(ident) in ["Candle"]:
+                if self.current_scene == 0x1c02:
+                    add_detection("tof_3f_candles", addr + 8, comp=[0, 3])
+
+            if identifiers.get(ident) in ["Boss Door"]:
+                self.boss_door_addr = addr
+                await self.open_boss_door(ctx)
+
+        if self.current_scene == 0x1c00:
+            add_detection("tof_arena", self.stage_flag_address+0, comp=0x10, comp_exact=False)
 
         for obj in self.paired_object_watches.copy().values():
             if not obj.validate():

--- a/worlds/tloz_ph/Client.py
+++ b/worlds/tloz_ph/Client.py
@@ -444,10 +444,18 @@ class PhantomHourglassClient(DSZeldaClient):
             writes = []
             for read, obj in zip(reads.values(), self.paired_object_watches.copy().values()):
                 if obj.compare(read):
+                    if obj.state:
+                        continue
                     if not hasattr(obj, "trigger_2") or obj.compare(await obj.trigger_2.read(ctx)):
                         printl(f"Paired object activated: {obj}")
                         writes += obj.get_writes()
-                        self.paired_object_watches.pop(obj.name)
+                        obj.state = True
+                        if not obj.always_active:
+                            self.paired_object_watches.pop(obj.name)
+                elif obj.always_active and obj.state:
+                    obj.state = False
+                    printl(f"Paired object reset: {obj}")
+                    writes += obj.get_writes(True)
             if writes:
                 await bizhawk.write(ctx.bizhawk_ctx, writes)
 
@@ -1569,10 +1577,10 @@ class PhantomHourglassClient(DSZeldaClient):
 
     async def process_map_objects(self, ctx):
 
-        table_size = await PHAddr.map_obj_table_size.read(ctx)*4
-        actor_idents = await self.get_table_data(ctx, PHAddr.map_obj_table, 0,
+        table_size = await PHAddr.map_obj_table_size.read(ctx)
+        obj_idents = await self.get_table_data(ctx, PHAddr.map_obj_table, 0,
                                                  size=3, table_label=False, table_size=table_size)
-        printl(f"map objects ({table_size}): {hex_f(actor_idents)}")
+        printl(f"map objects ({table_size}): {hex_f(obj_idents)}")
 
         identifiers = idents_0
 
@@ -1580,13 +1588,27 @@ class PhantomHourglassClient(DSZeldaClient):
             self.paired_object_watches.setdefault(name, PairedObjects(name)).set_detection(
                 Address.from_pointer(a), **kwargs)
 
-        def add_action(name, a):
-            self.paired_object_watches.setdefault(name, PairedObjects(name)).to_activate.append(
-                Address.from_pointer(a))
+        def add_action(name, a, w=0, r=2):
+            self.paired_object_watches.setdefault(name, PairedObjects(name)).set_action(
+                Address.from_pointer(a), w, r)
+
+        # Count items for rooms before looping
+        has_triangle, has_round, has_square = 0, 0, 0
+        if self.current_scene == 0x2900:
+            has_triangle = (self.item_count(ctx, "Triangle Crystal (Ghost Ship)")
+                    or self.item_count(ctx, "Triangle Crystals"))
+            has_round = (self.item_count(ctx, "Round Crystal (Ghost Ship)")
+                    or self.item_count(ctx, "Round Crystals"))
+
+        # Coordinate reads are currently reeeally slow. Test if faster to read them in bulk for all objects here?
+        xs = await read_multiple(ctx, obj_idents.keys(), signed=True, offset=6*4)
+        zs = await read_multiple(ctx, obj_idents.keys(), signed=True, offset=8*4)
 
         write_list = []
-        for i, pack in enumerate(actor_idents.items()):
-            addr, ident = pack
+        for i, pack in enumerate(zip(obj_idents.items(), list(xs.values()), list(zs.values()))):
+            pack2, x, z = pack
+            addr, ident = pack2
+            # print(i, addr, identifiers.get(ident), x, z)
             if addr == 0x5544:
                 printl("Map Object Overflow!")
                 break
@@ -1603,17 +1625,22 @@ class PhantomHourglassClient(DSZeldaClient):
             if identifiers.get(ident) in ["Spikes"]:
                 write_list.append(Address.from_pointer(addr + 30 * 4, size=2).get_inner_write_list(0))
 
+                if self.current_scene == 0x2900 and 20000 < x < 40000:
+                    if not ctx.slot_data["randomize_pedestal_items"]:
+                        write_list.pop()
+                    elif has_triangle:
+                        write_list.append(addr.get_inner_write_list(0, 8, 1))
+
             if identifiers.get(ident) in ["Bridge Spawner"]:
                 write_list.append(Address.from_pointer(addr + 15 * 4, size=2).get_inner_write_list(0))
 
             if identifiers.get(ident) in ["Torch"]:
                 write_list.append(Address.from_pointer(addr + 38 * 4 +2, size=2).get_inner_write_list(0))
-                if self.current_scene == 0x2501 and await Address.from_pointer(addr+6*4, size=4).read(ctx, signed=True) == -10240:
+                if self.current_scene == 0x2501 and x == -10240:
                     add_detection("b1_flames", addr+8)
-                if (self.current_scene == 0x1c02
-                        and await Address.from_pointer(addr + 8 * 4, size=4).read(ctx, signed=True) < -45000
-                        and await Address.from_pointer(addr + 6 * 4, size=4).read(ctx, signed=True) > -60000):
-                    add_detection("tof_3f_torches", addr+8)
+                if self.current_scene == 0x1c02:
+                    if z < -45000 and x > -60000:
+                        add_detection("tof_3f_torches", addr+8)
 
             if identifiers.get(ident) in ["Unspawned Big Chest", "Unspawned Small Chest"]:
                 write_list.append(Address.from_pointer(addr + 28 * 4, size=2).get_inner_write_list(0))
@@ -1625,20 +1652,20 @@ class PhantomHourglassClient(DSZeldaClient):
                     add_action("b1_flames", addr + 8)
 
                 elif self.current_scene == 0x2502:
-                    if await Address.from_pointer(addr+8*4, size=4).read(ctx, signed=True) == -6144:
+                    if z == -6144:
                         add_action("b2_lever", addr + 8)
                     else:
                         add_action("b2_switch", addr + 8)
 
                 elif self.current_scene == 0x2503:
-                    if await Address.from_pointer(addr + 8 * 4, size=4).read(ctx, signed=True) == -14336:
+                    if z == -14336:
                         write_list.pop()  # Phantom Flames actually use the cutscene flag
                         write_list.append(Address.from_pointer(addr + 42 * 4+2, size=2).get_inner_write_list(0))
                     else:
                         add_action("b3_lever", addr + 8)
 
                 elif self.current_scene == 0x250A:
-                    if await Address.from_pointer(addr + 8 * 4, size=4).read(ctx, signed=True) == -10240:
+                    if z == -10240:
                         add_action("b7_chest", addr + 8)
                     else:
                         write_list.pop()  # Phantom Flames actually use the cutscene flag
@@ -1648,29 +1675,44 @@ class PhantomHourglassClient(DSZeldaClient):
                     write_list.append(Address.from_pointer(addr + 42 * 4 + 2, size=2).get_inner_write_list(0))
 
                 elif self.current_scene == 0x1C00:
-                    coords = await read_multiple(ctx, [Address.from_pointer(addr + 6 * 4, size=4), Address.from_pointer(addr + 8 * 4, size=4)], signed=True)
-                    x, z = list(coords.values())
                     if x == -22528:
                         add_action("tof_1f", addr + 8)
                     elif z == 47104 and x > 20000:
                         add_action("tof_arena", addr + 8)
 
                 elif self.current_scene == 0x1c01:
-                    x = await Address.from_pointer(addr + 6 * 4, size=4).read(ctx, signed=True)
                     if x == 14336:
                         add_action("tof_2f_e", addr + 8)
                     elif x == -26624:
                         add_action("tof_2f_w", addr + 8)
 
                 if self.current_scene == 0x1C02:
-                    coords = await read_multiple(ctx, [Address.from_pointer(addr + 6 * 4, size=4), Address.from_pointer(addr + 8 * 4, size=4)], signed=True)
-                    x, z = list(coords.values())
                     if x < -20000:
                         write_list.pop()
                     elif x > 40000:
                         add_action("tof_3f_candles", addr + 8)
                     else:
                         add_action("tof_3f_torches", addr + 8)
+
+                elif self.current_scene == 0x2900:
+                    if x < 0:
+                        add_action("gs_1f", addr + 8)
+                    elif x < 35000:
+                        if not ctx.slot_data["randomize_pedestal_items"]:
+                            add_action("gs_round", addr + 8)
+                            # write_list.pop()
+                        elif has_round:
+                            write_list.append(addr.get_inner_write_list(0, 8, 1))
+                    else:
+                        if not ctx.slot_data["randomize_pedestal_items"]:
+                            add_action("gs_tri", addr + 8)
+                        elif has_triangle:
+                            write_list.append(addr.get_inner_write_list(0, 8, 1))
+                elif self.current_scene == 0x2902:
+                    if x > 0:
+                        add_action("gs_b3_e", addr + 8)
+                    else:
+                        add_action("gs_b3_w", addr + 8)
 
             if identifiers.get(ident) in ["Lever"]:
                 if self.current_scene == 0x2502:
@@ -1679,19 +1721,21 @@ class PhantomHourglassClient(DSZeldaClient):
                     add_detection("b3_lever", addr + 8, comp=3)
 
             if identifiers.get(ident) in ["Switch"]:
-                if self.current_scene == 0x2502 and await Address.from_pointer(addr+6*4, size=4).read(ctx, signed=True) == -55296:
+                if self.current_scene == 0x2502 and x == -55296:
                     add_detection("b2_switch", addr + 8, comp=1)
 
-                if self.current_scene == 0x1C00 and await Address.from_pointer(addr+8*4, size=4).read(ctx, signed=True) == -10240:
+                if self.current_scene == 0x1C00 and z == -10240:
                     add_detection("tof_1f", addr + 8, comp=1)
 
                 if self.current_scene == 0x1C01:
-                    x = await Address.from_pointer(addr+6*4, size=4).read(ctx, signed=True)
                     if x == 63488:
                         add_detection("tof_2f_e", addr + 8, comp=1)
                     elif x == -63488:
                         add_detection("tof_2f_w", addr + 8, comp=1)
 
+            if identifiers.get(ident) in ["Pressure Pad"]:
+                if self.current_scene == 0x2902:
+                    add_detection("gs_b3_w", addr + 8, comp=2)
 
             if identifiers.get(ident) in ["Small Chest"]:
                 if self.current_scene == 0x250A:
@@ -1705,8 +1749,24 @@ class PhantomHourglassClient(DSZeldaClient):
                 self.boss_door_addr = addr
                 await self.open_boss_door(ctx)
 
+            if identifiers.get(ident) in ["Pedestal"]:
+                if self.current_scene == 0x2900 and not ctx.slot_data["randomize_pedestal_items"]:
+                    if x > 40000:
+                        add_detection("gs_tri", addr + 8, comp=1, always_active=True)
+                    else:
+                        add_detection("gs_round", addr + 8, comp=1, always_active=True)
+
+            if identifiers.get(ident) in ["Small Chest", "Big Chest", "Unspawned Big Chest", "Unspawned Small Chest"]:
+                # Set chest contents?
+                pass
+
         if self.current_scene == 0x1c00:
             add_detection("tof_arena", self.stage_flag_address+0, comp=0x10, comp_exact=False)
+        elif self.current_scene == 0x2900:
+            add_detection("gs_1f", self.stage_flag_address+0, comp=0x4, comp_exact=False)
+        elif self.current_scene == 0x2902:
+            add_detection("gs_b3_e", self.stage_flag_address+3, comp=0x10, comp_exact=False)
+
 
         for obj in self.paired_object_watches.copy().values():
             if not obj.validate():

--- a/worlds/tloz_ph/Client.py
+++ b/worlds/tloz_ph/Client.py
@@ -213,9 +213,10 @@ class PhantomHourglassClient(DSZeldaClient):
         self.actor_table_pointer: Address | None = None
         self.last_actor_scan: list[int] = []
         self.linked_dig_spots: dict[str, int] = {}
-        self.key_door_watches: list["Address"] = []
+        self.key_door_watches: dict[Address, str] = {}
         self.paired_object_watches: dict[str, "PairedObjects"] = {}
         self.boss_door_addr: Address | None = None
+        self.stage_flags = STAGE_FLAGS
 
 
     async def check_game_version(self, ctx: "BizHawkClientContext") -> bool:
@@ -434,11 +435,12 @@ class PhantomHourglassClient(DSZeldaClient):
             reads = await read_multiple(ctx, self.key_door_watches)
             for a, v in reads.items():
                 if 8 > v > 2:
+                    printl(f"Opening key door {a}")
                     await write_multiple(ctx, [a, Address.from_pointer(a+28*4+2, 1)], [7, 0xff])
-                    self.key_door_watches.remove(a)
+                    self.key_door_watches.pop(a)
                     break
-                if v == 8:
-                    self.key_door_watches.remove(a)
+                if v == 8 and self.key_door_watches[a] == "key":
+                    self.key_door_watches.pop(a)
         if self.paired_object_watches:
             reads = await read_multiple(ctx, [obj.trigger for obj in self.paired_object_watches.values()])
             writes = []
@@ -454,7 +456,7 @@ class PhantomHourglassClient(DSZeldaClient):
                             self.paired_object_watches.pop(obj.name)
                 elif obj.always_active and obj.state:
                     obj.state = False
-                    printl(f"Paired object reset: {obj}")
+                    printl(f"Paired object reset: {obj} {obj.reset_write}")
                     writes += obj.get_writes(True)
             if writes:
                 await bizhawk.write(ctx.bizhawk_ctx, writes)
@@ -498,6 +500,16 @@ class PhantomHourglassClient(DSZeldaClient):
                                                       silent=True)
 
             self.last_gear = read_result[PHAddr.boat_gear]
+
+    def cancel_map_warp(self, ctx, going_to):
+        printl(f"Testing map warp {self.last_stage} {self.map_warp} {hex_f(going_to)}")
+        if going_to[0] == 0x25 and self.last_stage != 0x25:
+            logger.info(f"Canceling map warp, you can't warp while entering TotOK")
+            return True
+        if going_to[0] == 3 and self.map_warp.stage == 0:
+            logger.info(f"Canceling map warp, warping to the ocean with salvage crashes")
+            return True
+        return False
 
     async def process_slow(self, ctx: "BizHawkClientContext", read_result: dict):
         # Detect lowering of water and update ER Map
@@ -547,11 +559,15 @@ class PhantomHourglassClient(DSZeldaClient):
         # Process reloading of dig spots/bonk trees
         await self.repopulate_dig_spots(ctx)
 
-
-
     async def detect_warp_to_start(self, ctx, read_result: dict):
         # Opened clog warp to start check
         if read_result.get(PHAddr.opened_clog, False):
+
+            # finish delay reset on clog
+            if self.delay_reset:
+                self.delay_reset = 0
+                await self._remove_vanilla_item(ctx, read_result.get(self.addr_received_item_index, None))
+
             filpped_clog = await PHAddr.flipped_clog.read(ctx, silent=True)
             if not self.home_screen_warp_spam and filpped_clog & 1:
                 if not self.warp_to_start_flag:
@@ -646,8 +662,16 @@ class PhantomHourglassClient(DSZeldaClient):
         if self.current_stage == 0 and ctx.slot_data["randomize_fishing"]:
             await self.force_spawn_swordfish(ctx)
 
-        # Open boss door
-        # await self.open_boss_door(ctx)
+        if ctx.slot_data["randomize_pedestal_items"]:
+            if self.current_scene == 0x2510:  # B12
+                gem_count = self.item_count(ctx, "Force Gem (B12)") + self.item_count(ctx, "Force Gems")*3
+                if gem_count >= 3:
+                    await PHAddr.totok_b12_state.set_bits(ctx, [0xFE, 0x0F])
+                elif gem_count == 2:
+                    await PHAddr.totok_b12_state.set_bits(ctx, 0xC)
+                elif gem_count == 1:
+                    await PHAddr.totok_b12_state.set_bits(ctx, 0x8)
+
 
         # Find potential dig spots
         await self.load_dig_spots(ctx)
@@ -783,8 +807,8 @@ class PhantomHourglassClient(DSZeldaClient):
         printl(f"Setting stage flags")
         self.stage_flag_address = await get_address_from_heap(ctx, PHAddr.gMapManager, STAGE_FLAGS_OFFSET)
         self.key_address = Address.from_pointer(self.stage_flag_address + SMALL_KEY_OFFSET)
-        if stage in STAGE_FLAGS:
-            flags = STAGE_FLAGS[stage]
+        if stage in self.stage_flags:
+            flags = self.stage_flags[stage]
 
             printl(f"\tSetting Stage flags for {STAGES[stage]}, "
                   f"adr: {self.stage_flag_address}")
@@ -1005,7 +1029,8 @@ class PhantomHourglassClient(DSZeldaClient):
                 return game_clear
             if self.current_scene == 0x3300 and not self.defeated_bellum:
                 if await PHAddr.defeated_bellum.read(ctx, silent=True) == 1:
-                    if await PHAddr.potion_protector.read(ctx, silent=True):
+                    if (await PHAddr.potion_protector.read(ctx, silent=True)  # drink potion
+                            or await self.health_address.read(ctx) == 0):  # die and revive
                         printl(f"Tried to drink potion, don't send goal!")
                         await PHAddr.defeated_bellum.overwrite(ctx, 0, silent=True)
                     else:
@@ -1576,6 +1601,9 @@ class PhantomHourglassClient(DSZeldaClient):
         await bizhawk.write(ctx.bizhawk_ctx, write_list)
 
     async def process_map_objects(self, ctx):
+        if self.current_stage <=3:
+            return
+
 
         table_size = await PHAddr.map_obj_table_size.read(ctx)
         obj_idents = await self.get_table_data(ctx, PHAddr.map_obj_table, 0,
@@ -1592,19 +1620,52 @@ class PhantomHourglassClient(DSZeldaClient):
             self.paired_object_watches.setdefault(name, PairedObjects(name)).set_action(
                 Address.from_pointer(a), w, r)
 
-        # Count items for rooms before looping
-        has_triangle, has_round, has_square = 0, 0, 0
-        if self.current_scene == 0x2900:
-            has_triangle = (self.item_count(ctx, "Triangle Crystal (Ghost Ship)")
-                    or self.item_count(ctx, "Triangle Crystals"))
-            has_round = (self.item_count(ctx, "Round Crystal (Ghost Ship)")
-                    or self.item_count(ctx, "Round Crystals"))
+        def open_door(a):
+            printl(f"Opening door {a}")
+            write_list.append(a.get_inner_write_list(7, 28*4+2, 1))
+            write_list.append(a.get_inner_write_list(0x1000, 4*26, 2)) # Open
+            write_list.append(a.get_inner_write_list(0x1000, 4 * 31+2, 2)) # remove map icon
+            write_list.append(a.get_inner_write_list(0, 4 * 15, 2)) # disable collision
 
-        # Coordinate reads are currently reeeally slow. Test if faster to read them in bulk for all objects here?
+        def lower_spikes(a):
+            write_list.append(a.get_inner_write_list(0, 4, 2))
+
+        write_list = []
+        # Count items for rooms before looping, and set pedes0tal bits
+        has_triangle, has_round, has_square = 0, 0, 0
+        has_north, has_south, has_east, has_west = 0, 0, 0, 0
+        if not ctx.slot_data["randomize_pedestal_items"]:
+            pass
+        elif self.current_scene == 0x2900:
+            has_triangle = self.has_from_group(ctx, "gs_tri")
+            has_round = self.has_from_group(ctx, "gs_round")
+        elif self.current_scene == 0x250B:
+            has_triangle = self.has_from_group(ctx, "totok_tri_8")
+            has_round = self.has_from_group(ctx, "totok_round_8")
+            bit = 0
+            if has_triangle: bit |= 4
+            if has_round: bit |= 2
+            prev = await PHAddr.totok_b8_state.read(ctx)
+            write_list.append(PHAddr.totok_b8_state.get_inner_write_list(bit | prev))
+        elif self.current_scene == 0x250C:
+            has_triangle = self.has_from_group(ctx, "totok_tri_9")
+            has_round = self.has_from_group(ctx, "totok_round_9")
+            has_east = self.has_from_group(ctx, "totok_sq_e")
+            has_west = self.has_from_group(ctx, "totok_sq_w")
+            bit = 0
+            if has_round: bit |= 4
+            if has_triangle: bit |= 8
+            if has_east: bit |= 2
+            prev = await PHAddr.totok_b9_state.read(ctx)
+            write_list.append(PHAddr.totok_b9_state.get_inner_write_list(bit | prev))
+        elif self.current_scene == 0x1e00:
+            has_north = self.has_from_group(ctx, "toc_sq_n")
+            has_south = self.has_from_group(ctx, "toc_sq_s")
+
         xs = await read_multiple(ctx, obj_idents.keys(), signed=True, offset=6*4)
         zs = await read_multiple(ctx, obj_idents.keys(), signed=True, offset=8*4)
 
-        write_list = []
+
         for i, pack in enumerate(zip(obj_idents.items(), list(xs.values()), list(zs.values()))):
             pack2, x, z = pack
             addr, ident = pack2
@@ -1616,20 +1677,49 @@ class PhantomHourglassClient(DSZeldaClient):
                 printl(f"Unknown map object: {hex_f(ident)} @ {addr} #{i}")
                 continue
 
-            if identifiers.get(ident) in ["Spirit Door", "Key Door", "Blue Door", "Arena Door"]:
+            if identifiers.get(ident) in ["Spirit Door", "Key Door", "Blue Door", "Arena Door", "Door"]:
                 write_list.append(Address.from_pointer(addr + 31*4, size=2).get_inner_write_list(0))  # closing
 
                 if identifiers.get(ident) in ["Spirit Door", "Key Door"]:
-                    self.key_door_watches.append(Address.from_pointer(addr + 8, 1))
+                    self.key_door_watches[Address.from_pointer(addr + 8, 1)] = "key"
+                if identifiers.get(ident) in ["Arena Door"]:
+                    self.key_door_watches[Address.from_pointer(addr + 8, 1)] = "arena"
+
+                if identifiers.get(ident) in ["Blue Door"]:
+                    if self.current_scene in [0xb13]:
+                        write_list.pop()  # softlock in sign lol. do this for other doors opened from signs, like astrid's basement
+
+                    if self.current_scene == 0x1E00 and ctx.slot_data["randomize_pedestal_items"]:
+                        if (x, z) == (-16388, -47104) and has_north:
+                            open_door(addr)
+                        elif (x, z) == (-53252, 47104) and has_south:
+                            open_door(addr)
+
+                    if (self.current_scene == 0x2503 and (x, z) == (28668, -47104)
+                            and (self.item_count(ctx, "Force Gem (B3)") >= 3
+                                 or self.item_count(ctx, "Force Gems"))):
+                        open_door(addr)
+                        await PHAddr.totok_b3_state.set_bits(ctx, [0xFE, 0x0F])
+                    if (self.current_scene == 0x2510 and (x, z) == (28668, -47104)
+                            and (self.item_count(ctx, "Force Gem (B12)") >= 3
+                                 or self.item_count(ctx, "Force Gems"))):
+                        open_door(addr)
 
             if identifiers.get(ident) in ["Spikes"]:
                 write_list.append(Address.from_pointer(addr + 30 * 4, size=2).get_inner_write_list(0))
 
                 if self.current_scene == 0x2900 and 20000 < x < 40000:
                     if not ctx.slot_data["randomize_pedestal_items"]:
-                        write_list.pop()
+                        # write_list.pop() # not needed?
+                        pass
                     elif has_triangle:
-                        write_list.append(addr.get_inner_write_list(0, 8, 1))
+                        lower_spikes(addr)
+                if self.current_scene == 0x250B:
+                    if not ctx.slot_data["randomize_pedestal_items"]:
+                        # write_list.pop() # not needed?
+                        pass
+                    elif (has_round and x < 0) or (has_triangle and x > 0):
+                        lower_spikes(addr)
 
             if identifiers.get(ident) in ["Bridge Spawner"]:
                 write_list.append(Address.from_pointer(addr + 15 * 4, size=2).get_inner_write_list(0))
@@ -1642,8 +1732,40 @@ class PhantomHourglassClient(DSZeldaClient):
                     if z < -45000 and x > -60000:
                         add_detection("tof_3f_torches", addr+8)
 
-            if identifiers.get(ident) in ["Unspawned Big Chest", "Unspawned Small Chest"]:
+            if identifiers.get(ident) in ["Unspawned Big Chest", "Unspawned Small Chest"] and ctx.slot_data.get("chest_cutscene_skips", 0):
                 write_list.append(Address.from_pointer(addr + 28 * 4, size=2).get_inner_write_list(0))
+
+            if identifiers.get(ident) in ["Ice Spikes"]:
+                if not self.current_scene in [0xF01, 0xF03]:
+                    write_list.append(Address.from_pointer(addr + 25 * 4, size=1).get_inner_write_list(0))
+
+                if self.current_scene == 0x1F01:
+                    add_action("toi_3f", addr + 8, 2)
+
+                if self.current_scene == 0x1F03:
+                    add_action("toi_2f", addr + 8, 2)
+
+                if self.current_scene == 0x1F00:
+                    if z == -18432:
+                        add_action("toi_1f_n", addr + 8, 2)
+                    elif z == 30720:
+                        add_action("toi_1f_s", addr + 8, 2)
+
+                if self.current_scene == 0x1F02:
+                    if x == 55296:
+                        add_action("toi_b1_s", addr + 8, 2, 5)
+                    elif z == 22528:
+                        add_action("toi_b1_m", addr + 8, 2, 5)
+                    elif z == 43008:
+                        add_action("toi_b1_w", addr + 8, 2)
+
+                if self.current_scene == 0x1F05:
+                    if z == -2048:
+                        add_action("toi_b2_n", addr + 8, 2)
+                    elif z == 59392:
+                        add_action("toi_b2_w", addr + 8, 2)
+                    elif z == 47104:
+                        add_action("toi_b2_e", addr + 8, 2)
 
             if identifiers.get(ident) in ["Flames"]:
                 write_list.append(Address.from_pointer(addr + 42 * 4, size=4).get_inner_write_list(0))
@@ -1670,6 +1792,15 @@ class PhantomHourglassClient(DSZeldaClient):
                     else:
                         write_list.pop()  # Phantom Flames actually use the cutscene flag
                         write_list.append(Address.from_pointer(addr + 42 * 4 + 2, size=2).get_inner_write_list(0))
+                elif self.current_scene == 0x250C:
+                    if x == -51200:
+                        if not ctx.slot_data["randomize_pedestal_items"]:
+                            add_action("b9_flames", addr + 8)
+                        elif has_west:
+                            lower_spikes(addr)
+                    else:
+                        write_list.pop()  # Phantom Flames actually use the cutscene flag
+                        write_list.append(Address.from_pointer(addr + 42 * 4+2, size=2).get_inner_write_list(0))
                 elif self.current_scene in [0x2510, 0x2511]:
                     write_list.pop()  # Phantom Flames actually use the cutscene flag
                     write_list.append(Address.from_pointer(addr + 42 * 4 + 2, size=2).get_inner_write_list(0))
@@ -1702,12 +1833,12 @@ class PhantomHourglassClient(DSZeldaClient):
                             add_action("gs_round", addr + 8)
                             # write_list.pop()
                         elif has_round:
-                            write_list.append(addr.get_inner_write_list(0, 8, 1))
+                            lower_spikes(addr)
                     else:
                         if not ctx.slot_data["randomize_pedestal_items"]:
                             add_action("gs_tri", addr + 8)
                         elif has_triangle:
-                            write_list.append(addr.get_inner_write_list(0, 8, 1))
+                            lower_spikes(addr)
                 elif self.current_scene == 0x2902:
                     if x > 0:
                         add_action("gs_b3_e", addr + 8)
@@ -1727,6 +1858,12 @@ class PhantomHourglassClient(DSZeldaClient):
                 if self.current_scene == 0x1C00 and z == -10240:
                     add_detection("tof_1f", addr + 8, comp=1)
 
+                if self.current_scene == 0x1f01 and x > 0:
+                    add_detection("toi_3f", addr + 8, comp=1)
+
+                if self.current_scene == 0x1f02 and z == 14336:
+                    add_detection("toi_b1_m", addr + 8, comp=1, always_active=True)
+
                 if self.current_scene == 0x1C01:
                     if x == 63488:
                         add_detection("tof_2f_e", addr + 8, comp=1)
@@ -1736,6 +1873,25 @@ class PhantomHourglassClient(DSZeldaClient):
             if identifiers.get(ident) in ["Pressure Pad"]:
                 if self.current_scene == 0x2902:
                     add_detection("gs_b3_w", addr + 8, comp=2)
+                if self.current_scene == 0x1f05:
+                    if z == 63488:
+                        add_detection("toi_b2_w", addr + 8, comp=2)
+                    elif z == 55296:
+                        add_detection("toi_b2_e", addr + 8, comp=2)
+
+            if identifiers.get(ident) in ["Eye Switch"]:
+                if self.current_scene == 0x1f02:
+                    add_detection("toi_b1_w", addr + 8, comp=2)
+
+            if identifiers.get(ident) in ["Tongue Statue"]:
+                if self.current_scene == 0x1f00:
+                    if (x, z) == (-14336, -55296):
+                        add_detection("toi_1f_n", addr + 8, comp=3)
+                    elif z == 18432:
+                        add_detection("toi_1f_s", addr + 8, comp=3)
+                if self.current_scene == 0x1f02:
+                    if x == 67584:
+                        add_detection("toi_b1_s", addr + 8, comp=4, always_active=True)
 
             if identifiers.get(ident) in ["Small Chest"]:
                 if self.current_scene == 0x250A:
@@ -1755,6 +1911,14 @@ class PhantomHourglassClient(DSZeldaClient):
                         add_detection("gs_tri", addr + 8, comp=1, always_active=True)
                     else:
                         add_detection("gs_round", addr + 8, comp=1, always_active=True)
+                if self.current_scene == 0x250C and not ctx.slot_data["randomize_pedestal_items"]:
+                    if x == -63488:
+                        add_detection("b9_flames", addr + 8, comp=1, always_active=True)
+
+            if identifiers.get(ident) in ["Force Gem Pedestal"]:
+                if self.current_scene == 0x2510 and ctx.slot_data["randomize_pedestal_items"] and z==-22528:
+                    write_list.append(addr.get_inner_write_list(9, 4, 2))
+                    write_list.append(addr.get_inner_write_list(9, 4, 2))
 
             if identifiers.get(ident) in ["Small Chest", "Big Chest", "Unspawned Big Chest", "Unspawned Small Chest"]:
                 # Set chest contents?
@@ -1766,6 +1930,10 @@ class PhantomHourglassClient(DSZeldaClient):
             add_detection("gs_1f", self.stage_flag_address+0, comp=0x4, comp_exact=False)
         elif self.current_scene == 0x2902:
             add_detection("gs_b3_e", self.stage_flag_address+3, comp=0x10, comp_exact=False)
+        elif self.current_scene == 0x1f03:
+            add_detection("toi_2f", self.stage_flag_address+0, comp=0x10, comp_exact=False)
+        elif self.current_scene == 0x1f05:
+            add_detection("toi_b2_n", self.stage_flag_address+1, comp=0x4, comp_exact=False)
 
 
         for obj in self.paired_object_watches.copy().values():
@@ -1776,102 +1944,6 @@ class PhantomHourglassClient(DSZeldaClient):
         if write_list:
             printl(f"Deleting Cutscenes: {hex_f(write_list)}")
             await bizhawk.write(ctx.bizhawk_ctx, write_list)
-
-    async def open_gem_doors(self, ctx, door: "Address"):
-        # Open pedestal doors. sucks that you can't trigger it with dynaflags. slow code but game is slower
-        if ctx.slot_data.get("randomize_pedestal_items", 0) == 0:
-            return []
-
-        write_list = []
-
-        async def open_door():
-            printl(f"Opening door {door}")
-            door_open = Address.from_pointer(door+28*4+2, 1)
-            write_list.append(door_open.get_inner_write_list(7))
-            # await door.overwrite(ctx, 0x1000, offset=4 * 26)  # Open
-            # await door.overwrite(ctx, 0, offset=4 * 15)  # disable collision
-            # await door.unset_bits(ctx, 0x10, offset=4 * 1)  # remove map icon
-
-        async def lower_spikes(start_offset, check_offset, comp_value, width):
-            spike, offset = await self.find_table_object(ctx, start_offset, check_offset, comp_value, return_index=True)
-            if spike is None:
-                printl(f"Can't find spikes, probably already removed.")
-                return
-            reads: list[Address] = [Address.from_pointer(PHAddr.map_obj_table + 4 * (offset-i-1), size=3) for i in range(width-1)]
-            spikes = [spike] + list((await read_multiple(ctx, reads)).values())
-            printl(f"Lowering Spike objects: {spikes}")
-            if spike is None:
-                await self.print_map_data(ctx)
-            await write_multiple(ctx, [Address.from_pointer(a+4*i, size=4) for a in spikes for i in [1]], [0]*width)
-
-        # === TotOK ===
-        if self.current_scene == 0x2503:  # B3
-            if self.item_count(ctx, "Force Gem (B3)") >= 3 or self.item_count(ctx, "Force Gems"):
-                await PHAddr.totok_b3_state.set_bits(ctx, [0xFE, 0x0F])
-        elif self.current_scene == 0x250B:  # B8
-            if (self.item_count(ctx, "Triangle Crystal (Temple of the Ocean King)")
-                    or self.item_count(ctx, "Triangle Crystals")
-                    or self.item_count(ctx, "Triangle Pedestal B8 (Temple of the Ocean King)")):
-                await lower_spikes(12, 6, 14336, 3)
-                await PHAddr.totok_b8_state.set_bits(ctx, 0x4)
-            if (self.item_count(ctx, "Round Crystal (Temple of the Ocean King)")
-                    or self.item_count(ctx, "Round Pedestal B8 (Temple of the Ocean King)")
-                    or self.item_count(ctx, "Round Crystals")):
-                await lower_spikes(8, 6, 0xFFFF6800, 2)
-                await PHAddr.totok_b8_state.set_bits(ctx, 0x2)
-        elif self.current_scene == 0x250C:  # B9
-            if (self.item_count(ctx, "Round Crystal (Temple of the Ocean King)")
-                    or self.item_count(ctx, "Round Pedestal B9 (Temple of the Ocean King)")
-                    or self.item_count(ctx, "Round Crystals")):
-                await PHAddr.totok_b9_state.set_bits(ctx, 0x4)
-            if (self.item_count(ctx, "Triangle Crystal (Temple of the Ocean King)")
-                    or self.item_count(ctx, "Triangle Pedestal B9 (Temple of the Ocean King)")
-                    or self.item_count(ctx, "Triangle Crystals")):
-                await PHAddr.totok_b9_state.set_bits(ctx, 0x8)
-            if (self.item_count(ctx, "Square Crystal (Temple of the Ocean King)")
-                    or self.item_count(ctx, "Square Crystals")):
-                await PHAddr.totok_b9_state.set_bits(ctx,  0x02)
-                await lower_spikes(10, 6, 0xFFFF3800, 3)
-            if self.item_count(ctx, "Square Pedestal West (Temple of the Ocean King)"):
-                await lower_spikes(10, 6, 0xFFFF3800, 3)
-            if self.item_count(ctx, "Square Pedestal Center (Temple of the Ocean King)"):
-                await PHAddr.totok_b9_state.set_bits(ctx,  0x2)
-        elif self.current_scene == 0x2510:  # B12
-            gem_count = self.item_count(ctx, "Force Gem (B12)") | self.item_count(ctx, "Force Gems")*3
-            if gem_count >= 3:
-                await PHAddr.totok_b12_state.set_bits(ctx, [0xFE, 0x0F])
-            elif gem_count == 2:
-                await PHAddr.totok_b12_state.set_bits(ctx, 0xC)
-            elif gem_count == 1:
-                await PHAddr.totok_b12_state.set_bits(ctx, 0x8)
-            # Remove ability to place force gems on southern pedestals
-            await PHAddr.totok_b12_pedestal_left.overwrite(ctx, 0x9)
-            await PHAddr.totok_b12_pedestal_right.overwrite(ctx, 0x9)
-
-        # === Temple of Courage ===
-        elif self.current_scene == 0x1E00:
-            if (self.item_count(ctx, "Square Pedestal North (Temple of Courage)")
-                    or self.item_count(ctx, "Square Crystal (Temple of Courage)")
-                    or self.item_count(ctx, "Square Crystals")):
-                await open_door()
-            if (self.item_count(ctx, "Square Pedestal South (Temple of Courage)")
-                    or self.item_count(ctx, "Square Crystal (Temple of Courage)")
-                    or self.item_count(ctx, "Square Crystals")):
-                await open_door()
-
-        # === Ghost Ship ===
-        elif self.current_scene == 0x2900:
-            if (self.item_count(ctx, "Triangle Crystal (Ghost Ship)")
-                    or self.item_count(ctx, "Triangle Crystals")):
-                # await self.stage_flag_address.set_bits(ctx, 0x8, offset=1)
-                await lower_spikes(90, 6, 47104, 4)
-                await lower_spikes(85, 6, 38912, 3)
-            if (self.item_count(ctx, "Round Crystal (Ghost Ship)")
-                    or self.item_count(ctx, "Round Crystals")):
-                await lower_spikes(28, 6, 22528, 4)
-                # await self.stage_flag_address.set_bits(ctx, 0x2, offset=3)
-
-        return write_list
 
     async def get_object_read_addr(self, ctx, location) -> Address | None:
         vanilla_item_model = self.item_data[location["vanilla_item"]].vanilla_model
@@ -1893,7 +1965,8 @@ class PhantomHourglassClient(DSZeldaClient):
             # Always remove for previously checked locations
             if model_resets.get(model, ""):
                 printl(f"\tResetting model: {model_resets[model]}")
-                self.delay_reset += 1  # Add delay reset to make sure removal handling runs properly
+                if "gift_addr" in location:
+                    self.delay_reset += 1  # Add delay reset to make sure removal handling runs properly
                 await super()._set_vanilla_item(ctx, location, model_resets.get(model))
             return
         await super()._set_vanilla_item(ctx, location, vanilla_item)

--- a/worlds/tloz_ph/Client.py
+++ b/worlds/tloz_ph/Client.py
@@ -10,6 +10,7 @@ from .data.Entrances import entrance_id_to_entrance
 from .data.DynamicEntrances import DYNAMIC_ENTRANCES_BY_SCENE
 from typing import Literal, Iterable
 from settings import get_settings
+from .Subclasses import PairedObjects
 
 if TYPE_CHECKING:
     from worlds._bizhawk.context import BizHawkClientContext, BizHawkClientCommandProcessor
@@ -213,6 +214,7 @@ class PhantomHourglassClient(DSZeldaClient):
         self.last_actor_scan: list[int] = []
         self.linked_dig_spots: dict[str, int] = {}
         self.key_door_watches: list["Address"] = []
+        self.paired_object_watches: dict[str, "PairedObjects"] = {}
 
 
     async def check_game_version(self, ctx: "BizHawkClientContext") -> bool:
@@ -336,7 +338,7 @@ class PhantomHourglassClient(DSZeldaClient):
             if death_link_pointer:
                 addr, offset = death_link_pointer
                 pointer_1 = await addr.read(ctx)
-                self.health_address = Address.from_pointer(pointer_1 + offset - 0x2000000, size=2, name="link_health")
+                self.health_address = Address.from_pointer(pointer_1 + offset, size=2, name="link_health")
                 self.last_health_pointer = pointer_1
                 read_keys.append(self.health_address)
             printl(f"Health Address = {self.health_address}")
@@ -431,12 +433,22 @@ class PhantomHourglassClient(DSZeldaClient):
             reads = await read_multiple(ctx, self.key_door_watches)
             for a, v in reads.items():
                 if 8 > v > 2:
-
                     await write_multiple(ctx, [a, Address.from_pointer(a+28*4+2, 1)], [7, 0xff])
                     self.key_door_watches.remove(a)
                     break
                 if v == 8:
                     self.key_door_watches.remove(a)
+        if self.paired_object_watches:
+            reads = await read_multiple(ctx, [obj.trigger for obj in self.paired_object_watches.values()])
+            writes = []
+            for read, obj in zip(reads.values(), self.paired_object_watches.copy().values()):
+                if read == obj.comp:
+                    printl(f"Paired object activated: {obj}")
+                    writes += obj.get_writes()
+                    self.paired_object_watches.pop(obj.name)
+            if writes:
+                await bizhawk.write(ctx.bizhawk_ctx, writes)
+
 
         # Map warp entrypoint
         if read_result.get(PHAddr.in_map, 0):
@@ -509,6 +521,7 @@ class PhantomHourglassClient(DSZeldaClient):
                 printl(f"Reloading chests!")
                 await self.set_chest_contents(ctx)
                 await self.load_dig_spots(ctx)
+                await self.process_map_objects(ctx)
         if self.is_dead and not self.chest_reload_watches:
             self.chest_reload_watches.append((self.health_address, 0, "gt"))
             printl(f"Setting Chest reload for death: {self.chest_reload_watches}")
@@ -626,96 +639,6 @@ class PhantomHourglassClient(DSZeldaClient):
 
         # Open boss door
         await self.open_boss_door(ctx)
-
-        # Open pedestal doors. sucks that you can't trigger it with dynaflags. slow code but game is slower
-        if ctx.slot_data.get("randomize_pedestal_items", 0) > 0:
-            async def open_door(start_offset, check_offset, comp_value):
-                door = await self.find_table_object(ctx, start_offset, check_offset, comp_value)
-                printl(f"Opening door {door}")
-                if door:
-                    await door.overwrite(ctx, 0x1000, offset=4 * 26)  # Open
-                    await door.overwrite(ctx, 0, offset=4 * 15)  # disable collision
-                    await door.unset_bits(ctx, 0x10, offset=4 * 1)  # remove map icon
-
-            async def lower_spikes(start_offset, check_offset, comp_value, width):
-
-                spike, offset = await self.find_table_object(ctx, start_offset, check_offset, comp_value, return_index=True)
-                if spike is None:
-                    printl(f"Can't find spikes, probably already removed.")
-                    return
-                reads: list[Address] = [Address.from_pointer(PHAddr.map_obj_table + 4 * (offset-i-1), size=3) for i in range(width-1)]
-                spikes = [spike] + list((await read_multiple(ctx, reads)).values())
-                printl(f"Lowering Spike objects: {spikes}")
-                if spike is None:
-                    await self.print_map_data(ctx)
-                await write_multiple(ctx, [Address.from_pointer(a+4*i, size=4) for a in spikes for i in [1]], [0]*width)
-
-            # === TotOK ===
-            if current_scene == 0x2503:  # B3
-                if self.item_count(ctx, "Force Gem (B3)") >= 3 or self.item_count(ctx, "Force Gems"):
-                    await PHAddr.totok_b3_state.set_bits(ctx, [0xFE, 0x0F])
-            elif current_scene == 0x250B:  # B8
-                if (self.item_count(ctx, "Triangle Crystal (Temple of the Ocean King)")
-                        or self.item_count(ctx, "Triangle Crystals")
-                        or self.item_count(ctx, "Triangle Pedestal B8 (Temple of the Ocean King)")):
-                    await lower_spikes(12, 6, 14336, 3)
-                    await PHAddr.totok_b8_state.set_bits(ctx, 0x4)
-                if (self.item_count(ctx, "Round Crystal (Temple of the Ocean King)")
-                        or self.item_count(ctx, "Round Pedestal B8 (Temple of the Ocean King)")
-                        or self.item_count(ctx, "Round Crystals")):
-                    await lower_spikes(8, 6, 0xFFFF6800, 2)
-                    await PHAddr.totok_b8_state.set_bits(ctx, 0x2)
-            elif current_scene == 0x250C:  # B9
-                if (self.item_count(ctx, "Round Crystal (Temple of the Ocean King)")
-                        or self.item_count(ctx, "Round Pedestal B9 (Temple of the Ocean King)")
-                        or self.item_count(ctx, "Round Crystals")):
-                    await PHAddr.totok_b9_state.set_bits(ctx, 0x4)
-                if (self.item_count(ctx, "Triangle Crystal (Temple of the Ocean King)")
-                        or self.item_count(ctx, "Triangle Pedestal B9 (Temple of the Ocean King)")
-                        or self.item_count(ctx, "Triangle Crystals")):
-                    await PHAddr.totok_b9_state.set_bits(ctx, 0x8)
-                if (self.item_count(ctx, "Square Crystal (Temple of the Ocean King)")
-                        or self.item_count(ctx, "Square Crystals")):
-                    await PHAddr.totok_b9_state.set_bits(ctx,  0x02)
-                    await lower_spikes(10, 6, 0xFFFF3800, 3)
-                if self.item_count(ctx, "Square Pedestal West (Temple of the Ocean King)"):
-                    await lower_spikes(10, 6, 0xFFFF3800, 3)
-                if self.item_count(ctx, "Square Pedestal Center (Temple of the Ocean King)"):
-                    await PHAddr.totok_b9_state.set_bits(ctx,  0x2)
-            elif current_scene == 0x2510:  # B12
-                gem_count = self.item_count(ctx, "Force Gem (B12)") | self.item_count(ctx, "Force Gems")*3
-                if gem_count >= 3:
-                    await PHAddr.totok_b12_state.set_bits(ctx, [0xFE, 0x0F])
-                elif gem_count == 2:
-                    await PHAddr.totok_b12_state.set_bits(ctx, 0xC)
-                elif gem_count == 1:
-                    await PHAddr.totok_b12_state.set_bits(ctx, 0x8)
-                # Remove ability to place force gems on southern pedestals
-                await PHAddr.totok_b12_pedestal_left.overwrite(ctx, 0x9)
-                await PHAddr.totok_b12_pedestal_right.overwrite(ctx, 0x9)
-
-            # === Temple of Courage ===
-            elif current_scene == 0x1E00:
-                if (self.item_count(ctx, "Square Pedestal North (Temple of Courage)")
-                        or self.item_count(ctx, "Square Crystal (Temple of Courage)")
-                        or self.item_count(ctx, "Square Crystals")):
-                    await open_door(40, 6, 0xFFFFBFFC)
-                if (self.item_count(ctx, "Square Pedestal South (Temple of Courage)")
-                        or self.item_count(ctx, "Square Crystal (Temple of Courage)")
-                        or self.item_count(ctx, "Square Crystals")):
-                    await open_door(87, 6, 0xFFFF2FFC)
-
-            # === Ghost Ship ===
-            elif current_scene == 0x2900:
-                if (self.item_count(ctx, "Triangle Crystal (Ghost Ship)")
-                        or self.item_count(ctx, "Triangle Crystals")):
-                    # await self.stage_flag_address.set_bits(ctx, 0x8, offset=1)
-                    await lower_spikes(90, 6, 47104, 4)
-                    await lower_spikes(85, 6, 38912, 3)
-                if (self.item_count(ctx, "Round Crystal (Ghost Ship)")
-                        or self.item_count(ctx, "Round Crystals")):
-                    await lower_spikes(28, 6, 22528, 4)
-                    # await self.stage_flag_address.set_bits(ctx, 0x2, offset=3)
 
         # Find potential dig spots
         await self.load_dig_spots(ctx)
@@ -1546,6 +1469,10 @@ class PhantomHourglassClient(DSZeldaClient):
             await self._remove_vanilla_item(ctx, num_received_items)
         await self.receive_item_post_processing(ctx, item_name, item_data)
 
+    async def detected_new_scene(self, ctx: "BizHawkClientContext"):
+        self.key_door_watches.clear()
+        self.paired_object_watches.clear()
+
     @staticmethod
     async def find_table_object(ctx: "BizHawkClientContext", start_offset: int,
                               check_offset: int, comp_value: int | list,
@@ -1667,14 +1594,143 @@ class PhantomHourglassClient(DSZeldaClient):
             if identifiers.get(ident) in ["Bridge Spawner"]:
                 write_list.append(Address.from_pointer(addr + 15 * 4, size=2).get_inner_write_list(0))
 
+            if identifiers.get(ident) in ["Torch"]:
+                write_list.append(Address.from_pointer(addr + 38 * 4 +2, size=2).get_inner_write_list(0))
+                if self.current_scene == 0x2501 and await Address.from_pointer(addr+6*4, size=4).read(ctx, signed=True) == -10240:
+                    self.paired_object_watches.setdefault("b1_flames", PairedObjects("b1_flames")).trigger = Address.from_pointer(addr+8)
+
+            if identifiers.get(ident) in ["Unspawned Big Chest", "Unspawned Small Chest"]:
+                write_list.append(Address.from_pointer(addr + 28 * 4, size=2).get_inner_write_list(0))
+
+            if identifiers.get(ident) in ["Flames"]:
+                write_list.append(Address.from_pointer(addr + 42 * 4, size=4).get_inner_write_list(0))
+
+                if self.current_scene == 0x2501:
+                    self.paired_object_watches.setdefault("b1_flames", PairedObjects("b1_flames")).to_activate.append(Address.from_pointer(addr+8))
+
+                elif self.current_scene == 0x2502:
+                    if await Address.from_pointer(addr+8*4, size=4).read(ctx, signed=True) == -6144:
+                        self.paired_object_watches.setdefault("b2_lever", PairedObjects("b2_lever")).to_activate.append(Address.from_pointer(addr+8))
+                    else:
+                        self.paired_object_watches.setdefault("b2_switch", PairedObjects("b2_switch")).to_activate.append(Address.from_pointer(addr + 8))
+
+            if identifiers.get(ident) in ["Lever"]:
+                if self.current_scene == 0x2502:
+                    self.paired_object_watches.setdefault("b2_lever", PairedObjects("b2_lever")).set_detection(Address.from_pointer(addr + 8), 3)
+
+            if identifiers.get(ident) in ["Switch"]:
+                if self.current_scene == 0x2502 and await Address.from_pointer(addr+6*4, size=4).read(ctx, signed=True) == -55296:
+                    self.paired_object_watches.setdefault("b2_switch", PairedObjects("b2_switch")).set_detection(Address.from_pointer(addr + 8), 1)
+
+
             # if identifiers.get(i) in ["Boss Door"]:
             #     await self.open_boss_door(ctx, addr)
             #     self.boss_door_addr = addr
+
+        for obj in self.paired_object_watches.copy().values():
+            if not obj.validate():
+                self.paired_object_watches.pop(obj.name)
+        printl(f"Paired Objects: {self.paired_object_watches}")
 
         if write_list:
             printl(f"Deleting Cutscenes: {hex_f(write_list)}")
             await bizhawk.write(ctx.bizhawk_ctx, write_list)
 
+    async def open_gem_doors(self, ctx, door: "Address"):
+        # Open pedestal doors. sucks that you can't trigger it with dynaflags. slow code but game is slower
+        if ctx.slot_data.get("randomize_pedestal_items", 0) == 0:
+            return []
+
+        write_list = []
+
+        async def open_door():
+            printl(f"Opening door {door}")
+            door_open = Address.from_pointer(door+28*4+2, 1)
+            write_list.append(door_open.get_inner_write_list(7))
+            # await door.overwrite(ctx, 0x1000, offset=4 * 26)  # Open
+            # await door.overwrite(ctx, 0, offset=4 * 15)  # disable collision
+            # await door.unset_bits(ctx, 0x10, offset=4 * 1)  # remove map icon
+
+        async def lower_spikes(start_offset, check_offset, comp_value, width):
+            spike, offset = await self.find_table_object(ctx, start_offset, check_offset, comp_value, return_index=True)
+            if spike is None:
+                printl(f"Can't find spikes, probably already removed.")
+                return
+            reads: list[Address] = [Address.from_pointer(PHAddr.map_obj_table + 4 * (offset-i-1), size=3) for i in range(width-1)]
+            spikes = [spike] + list((await read_multiple(ctx, reads)).values())
+            printl(f"Lowering Spike objects: {spikes}")
+            if spike is None:
+                await self.print_map_data(ctx)
+            await write_multiple(ctx, [Address.from_pointer(a+4*i, size=4) for a in spikes for i in [1]], [0]*width)
+
+        # === TotOK ===
+        if self.current_scene == 0x2503:  # B3
+            if self.item_count(ctx, "Force Gem (B3)") >= 3 or self.item_count(ctx, "Force Gems"):
+                await PHAddr.totok_b3_state.set_bits(ctx, [0xFE, 0x0F])
+        elif self.current_scene == 0x250B:  # B8
+            if (self.item_count(ctx, "Triangle Crystal (Temple of the Ocean King)")
+                    or self.item_count(ctx, "Triangle Crystals")
+                    or self.item_count(ctx, "Triangle Pedestal B8 (Temple of the Ocean King)")):
+                await lower_spikes(12, 6, 14336, 3)
+                await PHAddr.totok_b8_state.set_bits(ctx, 0x4)
+            if (self.item_count(ctx, "Round Crystal (Temple of the Ocean King)")
+                    or self.item_count(ctx, "Round Pedestal B8 (Temple of the Ocean King)")
+                    or self.item_count(ctx, "Round Crystals")):
+                await lower_spikes(8, 6, 0xFFFF6800, 2)
+                await PHAddr.totok_b8_state.set_bits(ctx, 0x2)
+        elif self.current_scene == 0x250C:  # B9
+            if (self.item_count(ctx, "Round Crystal (Temple of the Ocean King)")
+                    or self.item_count(ctx, "Round Pedestal B9 (Temple of the Ocean King)")
+                    or self.item_count(ctx, "Round Crystals")):
+                await PHAddr.totok_b9_state.set_bits(ctx, 0x4)
+            if (self.item_count(ctx, "Triangle Crystal (Temple of the Ocean King)")
+                    or self.item_count(ctx, "Triangle Pedestal B9 (Temple of the Ocean King)")
+                    or self.item_count(ctx, "Triangle Crystals")):
+                await PHAddr.totok_b9_state.set_bits(ctx, 0x8)
+            if (self.item_count(ctx, "Square Crystal (Temple of the Ocean King)")
+                    or self.item_count(ctx, "Square Crystals")):
+                await PHAddr.totok_b9_state.set_bits(ctx,  0x02)
+                await lower_spikes(10, 6, 0xFFFF3800, 3)
+            if self.item_count(ctx, "Square Pedestal West (Temple of the Ocean King)"):
+                await lower_spikes(10, 6, 0xFFFF3800, 3)
+            if self.item_count(ctx, "Square Pedestal Center (Temple of the Ocean King)"):
+                await PHAddr.totok_b9_state.set_bits(ctx,  0x2)
+        elif self.current_scene == 0x2510:  # B12
+            gem_count = self.item_count(ctx, "Force Gem (B12)") | self.item_count(ctx, "Force Gems")*3
+            if gem_count >= 3:
+                await PHAddr.totok_b12_state.set_bits(ctx, [0xFE, 0x0F])
+            elif gem_count == 2:
+                await PHAddr.totok_b12_state.set_bits(ctx, 0xC)
+            elif gem_count == 1:
+                await PHAddr.totok_b12_state.set_bits(ctx, 0x8)
+            # Remove ability to place force gems on southern pedestals
+            await PHAddr.totok_b12_pedestal_left.overwrite(ctx, 0x9)
+            await PHAddr.totok_b12_pedestal_right.overwrite(ctx, 0x9)
+
+        # === Temple of Courage ===
+        elif self.current_scene == 0x1E00:
+            if (self.item_count(ctx, "Square Pedestal North (Temple of Courage)")
+                    or self.item_count(ctx, "Square Crystal (Temple of Courage)")
+                    or self.item_count(ctx, "Square Crystals")):
+                await open_door()
+            if (self.item_count(ctx, "Square Pedestal South (Temple of Courage)")
+                    or self.item_count(ctx, "Square Crystal (Temple of Courage)")
+                    or self.item_count(ctx, "Square Crystals")):
+                await open_door()
+
+        # === Ghost Ship ===
+        elif self.current_scene == 0x2900:
+            if (self.item_count(ctx, "Triangle Crystal (Ghost Ship)")
+                    or self.item_count(ctx, "Triangle Crystals")):
+                # await self.stage_flag_address.set_bits(ctx, 0x8, offset=1)
+                await lower_spikes(90, 6, 47104, 4)
+                await lower_spikes(85, 6, 38912, 3)
+            if (self.item_count(ctx, "Round Crystal (Ghost Ship)")
+                    or self.item_count(ctx, "Round Crystals")):
+                await lower_spikes(28, 6, 22528, 4)
+                # await self.stage_flag_address.set_bits(ctx, 0x2, offset=3)
+
+        return write_list
 
     async def get_object_read_addr(self, ctx, location) -> Address | None:
         vanilla_item_model = self.item_data[location["vanilla_item"]].vanilla_model

--- a/worlds/tloz_ph/Logic.py
+++ b/worlds/tloz_ph/Logic.py
@@ -454,7 +454,7 @@ def make_overworld_logic():
         ["ToW B2", "ToW B2 Dig", False, "shovel"],
         ["ToW B2", "ToW B2 Bombs", False, "explosives"],
         ["ToW B2", "ToW B2 Key", False, "tow_key"],
-        ["ToW B2 Bombs", "ToW 1F NE", False, "chus"],
+        ["ToW B2 Bombs", "ToW 1F NE", False, "bombs"],
         ["ToW 1F", "ToW 2F", False, "tow_cyclok"],
         ["ToW 2F", "Cyclok", True, None],
         ["ToW 2F", "ToW 1F", False, None],

--- a/worlds/tloz_ph/Options.py
+++ b/worlds/tloz_ph/Options.py
@@ -804,6 +804,15 @@ class PhantomHourglassMapWarp(Choice):
     # option_detailed = 3
     display_name = "Map Warp Options"
 
+class PhantomHourglassSkipChestCutscenes(Toggle):
+    """
+    Chest spawns with cutscene skips have zero feedback,
+    so if you don't know every chest trigger in the game you can turn their cutscene skips off again
+    True is skip cutscenes False is play cutscenes.
+    """
+    display_name = "Skip Chest Cutscenes"
+    default = 1
+
 @dataclass
 class PhantomHourglassOptions(PerGameCommonOptions):
     # Accessibility
@@ -889,6 +898,7 @@ class PhantomHourglassOptions(PerGameCommonOptions):
 
     # Cosmetic
     additional_metal_names: PhantomHourglassAdditionalMetalNames
+    chest_cutscene_skips: PhantomHourglassSkipChestCutscenes
 
     # UT options
     ut_smart_keys: PhantomHourglassUTSmartKeys
@@ -986,7 +996,8 @@ ph_option_groups = [
         PhantomHourglassUTEvents
     ]),
     OptionGroup("Cosmetic Options", [
-        PhantomHourglassAdditionalMetalNames
+        PhantomHourglassAdditionalMetalNames,
+        PhantomHourglassSkipChestCutscenes
     ]),
     OptionGroup("Item & Location Options", [
         PhantomHourglassAddItemsToPool,

--- a/worlds/tloz_ph/Subclasses.py
+++ b/worlds/tloz_ph/Subclasses.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 from BaseClasses import Entrance, Region
 from enum import IntEnum
 
-from .DSZeldaClient.subclasses import DSTransition, split_bits
+from .DSZeldaClient.subclasses import DSTransition, split_bits, Address
 from .DSZeldaClient.ItemClass import DSItem, remove_vanilla_normal
 from .data.SwitchLogic import *
 from .data.Constants import EQUIPPED_SHIP_PARTS_ADDR, BOSS_DOOR_DATA
@@ -104,7 +104,7 @@ async def remove_vanilla_throwable_keys(client: "PhantomHourglassClient", ctx: "
         return []
 
     # Get the actor table
-    actor_table_addr =  AddrFromPointer(await PHAddr.actor_table_pointer.read(ctx, silent=True), size=256)
+    actor_table_addr =  Address.from_pointer(await PHAddr.actor_table_pointer.read(ctx, silent=True), size=256)
     actor_table = hex(await actor_table_addr.read(ctx, silent=True))
     actor_table = "0" + actor_table[2:]
     print(f"Removing throwable key {item.name} with bk_id {bk_id}")
@@ -115,11 +115,11 @@ async def remove_vanilla_throwable_keys(client: "PhantomHourglassClient", ctx: "
         if actor_data[1] == "0":  # filter out empty slots
             continue
         print(actor_data)
-        actor_id_addr = AddrFromPointer(int(actor_data, 16) + 8 - 0x2000000, size=4)
+        actor_id_addr = Address.from_pointer(int(actor_data, 16) + 8 - 0x2000000, size=4)
         actor_id = await actor_id_addr.read(ctx, silent=True)
         # If you find the boss key, delete its pointer
         if actor_id == bk_id:
-            little_endian_lol = AddrFromPointer(actor_table_addr + len(actor_table) // 2 - (_i + 1) * 4, size=4)
+            little_endian_lol = Address.from_pointer(actor_table_addr + len(actor_table) // 2 - (_i + 1) * 4, size=4)
             print(f"Found bk pointer: {actor_table_addr} at index {_i}")
             await little_endian_lol.overwrite(ctx, 0, silent=True)
             break
@@ -463,3 +463,29 @@ def update_switch_logic(old_ex: "PHEntrance", entr: "PHEntrance", er_state, logi
         ex.global_switch_state = old_ex.global_switch_state
         ex.switch_state = old_ex.switch_state
 
+class PairedObjects:
+    name: str
+    trigger: "Address"
+    to_activate: list["Address"]
+    overwrite: int = 0
+    comp: int = 1
+
+    def __init__(self, name):
+        self.name = name
+        self.to_activate = []
+
+    def __repr__(self):
+        return f"{self.name}: {self.trigger} = {self.comp}, {self.to_activate} = {self.overwrite}"
+
+    def validate(self):
+        return self.to_activate and hasattr(self, "trigger")
+
+    def get_writes(self):
+        res = []
+        for addr in self.to_activate:
+            res.append(addr.get_inner_write_list(self.overwrite))
+        return res
+
+    def set_detection(self, trigger, comp=1):
+        self.trigger = trigger
+        self.comp = comp

--- a/worlds/tloz_ph/Subclasses.py
+++ b/worlds/tloz_ph/Subclasses.py
@@ -478,25 +478,36 @@ class PairedObjects:
         self.overwrite = 0
         self.comp_exact = True
 
+        self.always_active: bool = False
+        self.state: bool = False  # toggle state when always active
+        self.reset_write: int = 0  # What to write to reset
+
     def __repr__(self):
         return f"{self.name}: {self.trigger} = {self.comp}, {self.to_activate} = {self.overwrite}"
 
     def validate(self):
         return self.to_activate and hasattr(self, "trigger")
 
-    def get_writes(self):
+    def get_writes(self, reset=False):
         res = []
+        v = self.reset_write if reset else self.overwrite
         for addr in self.to_activate:
-            res.append(addr.get_inner_write_list(self.overwrite))
+            res.append(addr.get_inner_write_list(v))
         return res
 
-    def set_detection(self, trigger, comp=1, comp_exact=True):
+    def set_detection(self, trigger, comp=1, comp_exact=True, always_active=False):
         if not hasattr(self, "trigger"):
             self.trigger = trigger
             self.comp = comp
             self.comp_exact = comp_exact
+            self.always_active = always_active
         else:
             self.trigger_2 = trigger
+
+    def set_action(self, activate, w, r):
+        self.to_activate.append(activate)
+        self.overwrite = w
+        self.reset_write = r
 
     def compare(self, value):
         if self.comp_exact:

--- a/worlds/tloz_ph/Subclasses.py
+++ b/worlds/tloz_ph/Subclasses.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 from BaseClasses import Entrance, Region
 from enum import IntEnum
 
-from .DSZeldaClient.subclasses import DSTransition, split_bits, AddrFromPointer
+from .DSZeldaClient.subclasses import DSTransition, split_bits
 from .DSZeldaClient.ItemClass import DSItem, remove_vanilla_normal
 from .data.SwitchLogic import *
 from .data.Constants import EQUIPPED_SHIP_PARTS_ADDR, BOSS_DOOR_DATA

--- a/worlds/tloz_ph/Subclasses.py
+++ b/worlds/tloz_ph/Subclasses.py
@@ -467,12 +467,16 @@ class PairedObjects:
     name: str
     trigger: "Address"
     to_activate: list["Address"]
-    overwrite: int = 0
-    comp: int = 1
+    overwrite: int
+    comp: int
+    trigger_2: "Address"
 
     def __init__(self, name):
         self.name = name
         self.to_activate = []
+        self.comp = 1
+        self.overwrite = 0
+        self.comp_exact = True
 
     def __repr__(self):
         return f"{self.name}: {self.trigger} = {self.comp}, {self.to_activate} = {self.overwrite}"
@@ -486,6 +490,17 @@ class PairedObjects:
             res.append(addr.get_inner_write_list(self.overwrite))
         return res
 
-    def set_detection(self, trigger, comp=1):
-        self.trigger = trigger
-        self.comp = comp
+    def set_detection(self, trigger, comp=1, comp_exact=True):
+        if not hasattr(self, "trigger"):
+            self.trigger = trigger
+            self.comp = comp
+            self.comp_exact = comp_exact
+        else:
+            self.trigger_2 = trigger
+
+    def compare(self, value):
+        if self.comp_exact:
+            if isinstance(self.comp, int):
+                return value == self.comp
+            return value in self.comp
+        return value & self.comp

--- a/worlds/tloz_ph/__init__.py
+++ b/worlds/tloz_ph/__init__.py
@@ -248,7 +248,8 @@ class PhantomHourglassWorld(World):
                         continue
                     if "Unnamed Entrance" in event.name:
                         continue
-                    if self.options.dungeon_hint_type.value == 2 and event.name in BOSS_EVENT_TO_LOCATION and BOSS_EVENT_TO_LOCATION[event.name] not in required_dungeon_locations:
+                    if (self.options.dungeon_hint_type.value == 2 and event.name in BOSS_EVENT_TO_LOCATION
+                            and BOSS_EVENT_TO_LOCATION[event.name] not in required_dungeon_locations):
                         continue
 
                     print(f"Adding Event: {event.name} {event.id} => {event.vanilla_reciprocal.id}")
@@ -1008,6 +1009,7 @@ class PhantomHourglassWorld(World):
                 continue
 
             item_name = loc_data.get("item_override", loc_data["vanilla_item"])
+            # print(f"item: {item_name} from {loc_name}")
             if item_name == "Filler Item":
                 filler_item_count += 1
                 continue
@@ -1127,6 +1129,7 @@ class PhantomHourglassWorld(World):
                     random_filler_item = self.get_filler_item_name()
                     item_pool_dict[random_filler_item] = item_pool_dict.get(random_filler_item, 0) + 1
 
+        # print(item_pool_dict)
         return item_pool_dict
 
     def create_items(self):
@@ -1394,7 +1397,7 @@ class PhantomHourglassWorld(World):
             # PH settings
             "ph_time_logic", "ph_starting_time", "ph_time_increment", "ph_heart_time", "ph_required",
             # Cosmetic
-            "additional_metal_names",
+            "additional_metal_names", "chest_cutscene_skips",
             # ER
             "shuffle_dungeon_entrances", "shuffle_ports", "shuffle_caves", "shuffle_houses",
             "shuffle_overworld_transitions", "shuffle_bosses",

--- a/worlds/tloz_ph/archipelago.json
+++ b/worlds/tloz_ph/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "The Legend of Zelda - Phantom Hourglass",
-  "world_version": "0.9.4",
+  "world_version": "0.9.5",
   "authors": ["carrotinator", "Tanker50207", "palex00", "CelestialKitsune", "DayKat", "1313e", "Catzador"],
   "minimum_ap_version": "0.6.3"
 }

--- a/worlds/tloz_ph/data/Addresses.py
+++ b/worlds/tloz_ph/data/Addresses.py
@@ -1,4 +1,4 @@
-from ..DSZeldaClient.subclasses import Address, Pointer, SRAM
+from ..DSZeldaClient.subclasses import Address, SRAM, DTCM
 
 addr_null = Address(0, 0)
 
@@ -78,12 +78,12 @@ class PHAddr:
     actor_table_pointer = Address(0x1BA8C4, size=3)
 
     # Pointers
-    gItemManager = Pointer(0x0fb4)
-    gPlayerManager = Pointer(0x0fbc)
-    gAdventureFlags = Pointer(0x0f74)
-    gPlayer = Pointer(0x0f90)
-    # gOverlayManager_mLoadedOverlays_4 = Pointer(0x0910)
-    gMapManager = Pointer(0x0e60)
+    gItemManager = DTCM(0x0fb4)
+    gPlayerManager = DTCM(0x0fbc)
+    gAdventureFlags = DTCM(0x0f74)
+    gPlayer = DTCM(0x0f90)
+    # gOverlayManager_mLoadedOverlays_4 = DTCM(0x0910)
+    gMapManager = DTCM(0x0e60)
     
     # Adventure flags
     adv_flags = Address(0x1B557C, size=52)

--- a/worlds/tloz_ph/data/Addresses.py
+++ b/worlds/tloz_ph/data/Addresses.py
@@ -272,8 +272,8 @@ class PHAddr:
     # island_visible_ = Address()
     # island_visible_ = Address()
 
-    map_obj_table = Address(0x1B8968)  # size biig
-    map_obj_table_size = Address(0x1B896c)
+    map_obj_table = Address(0x1B8968)  # size biig, manager @ 0xF68 -> 0x1B853C + 3
+    map_obj_table_size = Address(0x1B854C, size=2)
 
     defeated_bellum = Address(0x1b5774)
     potion_protector = Address(0x1BA70a)

--- a/worlds/tloz_ph/data/Addresses.py
+++ b/worlds/tloz_ph/data/Addresses.py
@@ -273,6 +273,7 @@ class PHAddr:
     # island_visible_ = Address()
 
     map_obj_table = Address(0x1B8968)  # size biig
+    map_obj_table_size = Address(0x1B896c)
 
     defeated_bellum = Address(0x1b5774)
     potion_protector = Address(0x1BA70a)

--- a/worlds/tloz_ph/data/Constants.py
+++ b/worlds/tloz_ph/data/Constants.py
@@ -1957,9 +1957,11 @@ idents_0: dict[int, str] = {
     0x159254: "Bridge Spawner",
 
     0x16badc: "Boss Door",
+    0x159c10: "Ghost Door",
 
     0x156fc0: "Stone Tablet",
     0x16c47c: "Gossip Stone",
+    0x1592e8: "Gossip Stone (chest count)",
     0x157640: "Torch",
 
     0x15759C: "Switch",
@@ -1971,13 +1973,16 @@ idents_0: dict[int, str] = {
     0x185c44: "Lazer Statue",
     0x178e3c: "Candle",
 
+
     0x156CF8: "Pot (Hearts)",
     0x156c60: "Pot",
     0x156d90: "Pot (Safe Zone)",
+    0x17a1a8: "Barrel",
 
     0x15741c: "Peg",
     0x1576d4: "Dirt Pile",
     0x17a92c: "Force Gem Pedestal",
+    0x16bbb8: "Pedestal",
 
     0x16CB04: "Staircase",
     0xe2d44: "Staircase",

--- a/worlds/tloz_ph/data/Constants.py
+++ b/worlds/tloz_ph/data/Constants.py
@@ -1944,14 +1944,19 @@ idents_0: dict[int, str] = {
     0x156498: "Blue Door",
     0x157340: "Spikes",
     0x179104: "Ice Spikes",
-    0x259fc8: "Arena Door",
+    0x15a3c0: "Arena Door",
     0x157288: "Flames",
+    0x17ad60: "Blue Door",  # Phantom Door
 
     0x155fd4: "Small Chest",
-    0x1562AC: "Closed Chest",
+    0x1562AC: "Big Chest",
     0x1563f4: "Unspawned Big Chest",
-    0x156208: "Unspawned Small Chest",
+    0x156350: "Unspawned Big Chest",  # Boomerang chest enables item menu
+    0x156208: "Unspawned Small Chest",  # totok
+    0x15611c: "Unspawned Small Chest",  # tof
     0x159254: "Bridge Spawner",
+
+    0x16badc: "Boss Door",
 
     0x156fc0: "Stone Tablet",
     0x16c47c: "Gossip Stone",
@@ -1961,8 +1966,10 @@ idents_0: dict[int, str] = {
     0x16c3d4: "Color Switch",
     0x16c2f0: "Lever",
     0x1574b0: "Pressure Pad",
+    0x16c528: "Hammer Switch",
     0x15a628: "Eye Switch",
     0x185c44: "Lazer Statue",
+    0x178e3c: "Candle",
 
     0x156CF8: "Pot (Hearts)",
     0x156c60: "Pot",
@@ -1970,11 +1977,13 @@ idents_0: dict[int, str] = {
 
     0x15741c: "Peg",
     0x1576d4: "Dirt Pile",
+    0x17a92c: "Force Gem Pedestal",
 
     0x16CB04: "Staircase",
     0xe2d44: "Staircase",
     0x156B34: "Cave Exit",
     0x156a0c: "Cave",
+    0x156978: "Indoor Cave",
     0x156aa0: "Bombable Cave",
 
     0x179198: "Ice Bridge",
@@ -1989,6 +1998,8 @@ idents_0: dict[int, str] = {
     0x16cbac: "Tree",
 
     0x16cc40: "Grass",
+    0x16c9dc: "Pit Trap",
+    0x16cc74: "Hammer Catapult"
 }
 
 map_object_idents: dict[int, str] = {

--- a/worlds/tloz_ph/data/Constants.py
+++ b/worlds/tloz_ph/data/Constants.py
@@ -333,7 +333,6 @@ STAGE_LOCATION_GROUPS = {
         "TotOK B12 Kill Everything Chest",
         "TotOK B12 Phantom Chest",
         "TotOK B13 Sea Chart Chest",
-        "GOAL: Triforce Door",
     ],
     "Ocean": [
         "Ocean SW Salvage Courage Crest",
@@ -1282,7 +1281,8 @@ BOSS_EVENT_TO_LOCATION = {
     "EVENT: Defeat Blaaz": "Blaaz Boss Reward",
     "EVENT: Defeat Cyclok": "Cyclok Boss Reward",
     "EVENT: Defeat Crayk": "Crayk Boss Reward",
-    "EVENT: Rescue Tetra": ["Ghost Ship Rescue Tetra", "Cubus Sisters Ghost Key"],
+    "EVENT: Rescue Tetra": "Ghost Ship Rescue Tetra",
+    "EVENT: Defeat Cubus Sisters": "Cubus Sisters Ghost Key",
     "EVENT: Defeat Dongorongo": "Dongorongo Boss Reward",
     "EVENT: Defeat Gleeok": "Gleeok Boss Reward",
     "EVENT: Defeat Eox": "Eox Boss Reward",
@@ -1942,11 +1942,22 @@ idents_0: dict[int, str] = {
     0x17A864: "Spirit Door",
     0x15667C: "Key Door",
     0x156498: "Blue Door",
+    0x15a3c0: "Arena Door",
+    0x17ad60: "Blue Door",  # Phantom Door
+    0x16badc: "Boss Door",
+    0x159c10: "Ghost Door",
+    0x17930c: "Door",  # ToF Door
+    0x1568c0: "Tap Door",
+    0x170ff0: "Door",  # Sun door
+    0x185ce8: "Door", # Courage temple
+    0x263d20: "Door",  # Man of smiles arena door
+    0x16c188: "Door",  # Wireframe, in gt
+    0x17a9b8: "Door",  # Dongorongo's room
+    0x17aa70: "Door", # Dongorongo's room
+
     0x157340: "Spikes",
     0x179104: "Ice Spikes",
-    0x15a3c0: "Arena Door",
     0x157288: "Flames",
-    0x17ad60: "Blue Door",  # Phantom Door
 
     0x155fd4: "Small Chest",
     0x1562AC: "Big Chest",
@@ -1955,14 +1966,13 @@ idents_0: dict[int, str] = {
     0x156208: "Unspawned Small Chest",  # totok
     0x15611c: "Unspawned Small Chest",  # tof
     0x159254: "Bridge Spawner",
-
-    0x16badc: "Boss Door",
-    0x159c10: "Ghost Door",
+    0x17a924: "Bridge",  # Dongorong's room
 
     0x156fc0: "Stone Tablet",
-    0x16c47c: "Gossip Stone",
+    0x16c47c: "Tongue Statue",
     0x1592e8: "Gossip Stone (chest count)",
     0x157640: "Torch",
+    0x157160: "Map",
 
     0x15759C: "Switch",
     0x16c3d4: "Color Switch",
@@ -1973,11 +1983,12 @@ idents_0: dict[int, str] = {
     0x185c44: "Lazer Statue",
     0x178e3c: "Candle",
 
-
     0x156CF8: "Pot (Hearts)",
     0x156c60: "Pot",
     0x156d90: "Pot (Safe Zone)",
     0x17a1a8: "Barrel",
+    0x157054: "Bomb Flower",
+    0x15aaac: "Chestnut",
 
     0x15741c: "Peg",
     0x1576d4: "Dirt Pile",
@@ -1990,6 +2001,7 @@ idents_0: dict[int, str] = {
     0x156a0c: "Cave",
     0x156978: "Indoor Cave",
     0x156aa0: "Bombable Cave",
+    0x15a8d0: "Dungeon Entrance",
 
     0x179198: "Ice Bridge",
     0x16c614: "Color Block",
@@ -1999,10 +2011,14 @@ idents_0: dict[int, str] = {
     0xe289c: "Offscreen",
     0x15a328: "Bombable Wall",
     0x15a294: "Bombable Block",
+    0x15a114: "Block",
     0x157790: "Bombable Rock",
     0x16cbac: "Tree",
+    0x15a080: "Column",
+    0x15a534: "Bridge",
 
     0x16cc40: "Grass",
+    0x16ccd4: "Grass",
     0x16c9dc: "Pit Trap",
     0x16cc74: "Hammer Catapult"
 }
@@ -2033,6 +2049,14 @@ map_object_idents: dict[int, str] = {
     0x11d: "Pedestal",
     0x40d: "Repeater"
 }
+
+pedestal_rooms: list[int] = [
+    0x2900,
+    0x1E00,
+    0x2503,
+    0x250C,
+    0x2510
+]
 
 if __name__ == "__main__":
     for cat, value in CATEGORY_LOCATION_GROUPS.items():

--- a/worlds/tloz_ph/data/Constants.py
+++ b/worlds/tloz_ph/data/Constants.py
@@ -1943,14 +1943,45 @@ idents_0: dict[int, str] = {
     0x15667C: "Key Door",
     0x156498: "Blue Door",
     0x157340: "Spikes",
+    0x179104: "Ice Spikes",
+    0x259fc8: "Arena Door",
 
+    0x155fd4: "Small Chest",
     0x1562AC: "Closed Chest",
-    0x15759C: "Switch",
+    0x1563f4: "Unspawned Chest",
+    0x159254: "Bridge Spawner",
 
-    0x156CF8: "Pot",
+    0x156fc0: "Stone Tablet",
+    0x16c47c: "Gossip Stone",
+
+    0x15759C: "Switch",
+    0x16c3d4: "Color Switch",
+    0x16c2f0: "Lever",
+    0x1574b0: "Pressure Pad",
+    0x15a628: "Eye Switch",
+    0x185c44: "Lazer Statue",
+
+    0x156CF8: "Pot (Hearts)",
+    0x156c60: "Pot",
+
+    0x15741c: "Peg",
 
     0x16CB04: "Staircase",
-    0x156B34: "Cave Exit"
+    0xe2d44: "Staircase",
+    0x156B34: "Cave Exit",
+    0x156a0c: "Cave",
+    0x156aa0: "Bombable Cave",
+
+    0x179198: "Ice Bridge",
+    0x16c614: "Color Block",
+    0x25e448: "Separator",
+    0x25a308: "Separator (Corner)",
+    0xe289c: "Offscreen",
+    0x15a328: "Bombable Wall",
+    0x157790: "Bombable Rock",
+    0x16cbac: "Tree",
+
+    0x16cc40: "Grass",
 }
 
 map_object_idents: dict[int, str] = {

--- a/worlds/tloz_ph/data/Constants.py
+++ b/worlds/tloz_ph/data/Constants.py
@@ -1938,6 +1938,47 @@ dig_spot_data_water = {
     #                                               0x0225B1A0, dangerous_reset=True),
 }
 
+idents_0: dict[int, str] = {
+    0x17A864: "Spirit Door",
+    0x15667C: "Key Door",
+    0x156498: "Blue Door",
+    0x157340: "Spikes",
+
+    0x1562AC: "Closed Chest",
+    0x15759C: "Switch",
+
+    0x156CF8: "Pot",
+
+    0x16CB04: "Staircase",
+    0x156B34: "Cave Exit"
+}
+
+map_object_idents: dict[int, str] = {
+    1: "Unspawned",
+    0x5: "House Entrance",
+    0x2D: "Closed Chest",
+    0x29: "Open Chest",
+    0x819: "Door",
+    0x9: "Solid",
+    0x6F: "Throwable",
+    0xD: "Readable or Entrance",
+    0xF: "Barrel in Cave",
+    0x19: "House",
+    0x49: "Grass",
+    0x80D: "Cave Exit",
+    0x44D: "Switch",
+    0x801: "Buried Laser Statue",
+    0x809: "Staircase",
+    0x81D: "Tap Door, lit Laser Statue",
+    0x4D: "Hammer Switch",
+    0xC1D: "Unlit Laser Statue",
+    0x4F: "Bomb Flower",
+    0x20D: "Updraft",
+    0x209: "Dirt Pile",
+    0x429: "Lit Torch",
+    0x11d: "Pedestal",
+    0x40d: "Repeater"
+}
 
 if __name__ == "__main__":
     for cat, value in CATEGORY_LOCATION_GROUPS.items():

--- a/worlds/tloz_ph/data/Constants.py
+++ b/worlds/tloz_ph/data/Constants.py
@@ -1945,14 +1945,17 @@ idents_0: dict[int, str] = {
     0x157340: "Spikes",
     0x179104: "Ice Spikes",
     0x259fc8: "Arena Door",
+    0x157288: "Flames",
 
     0x155fd4: "Small Chest",
     0x1562AC: "Closed Chest",
-    0x1563f4: "Unspawned Chest",
+    0x1563f4: "Unspawned Big Chest",
+    0x156208: "Unspawned Small Chest",
     0x159254: "Bridge Spawner",
 
     0x156fc0: "Stone Tablet",
     0x16c47c: "Gossip Stone",
+    0x157640: "Torch",
 
     0x15759C: "Switch",
     0x16c3d4: "Color Switch",
@@ -1963,8 +1966,10 @@ idents_0: dict[int, str] = {
 
     0x156CF8: "Pot (Hearts)",
     0x156c60: "Pot",
+    0x156d90: "Pot (Safe Zone)",
 
     0x15741c: "Peg",
+    0x1576d4: "Dirt Pile",
 
     0x16CB04: "Staircase",
     0xe2d44: "Staircase",
@@ -1976,8 +1981,10 @@ idents_0: dict[int, str] = {
     0x16c614: "Color Block",
     0x25e448: "Separator",
     0x25a308: "Separator (Corner)",
+    0xe4e04: "Separator",
     0xe289c: "Offscreen",
     0x15a328: "Bombable Wall",
+    0x15a294: "Bombable Block",
     0x157790: "Bombable Rock",
     0x16cbac: "Tree",
 

--- a/worlds/tloz_ph/data/DynamicFlags.py
+++ b/worlds/tloz_ph/data/DynamicFlags.py
@@ -1,4 +1,5 @@
 from .Addresses import *
+from .Constants import SKIP_OCEAN_FIGHTS_FLAGS, SPAWN_B3_REAPLING_FLAGS
 
 """
 "Dynamic Flag Name": {
@@ -1456,6 +1457,18 @@ DYNAMIC_FLAGS = {
         "on_scenes": [0, 1, 2, 3],
         "has_items": [("NE Sea Chart", 0)],
         "unset_if_true": [(PHAddr.inventory_5, 0x10)]
+    },
+
+    # Stage Flaggery
+    "Skip ocean fights": {
+        "on_scenes": [0, 1, 2, 3],
+        "has_slot_data": [("skip_ocean_fights", 1)],
+        "update_stage_flags": SKIP_OCEAN_FIGHTS_FLAGS
+    },
+    "Spawn gs b3 reapling": {
+        "on_scenes": [0x4102],
+        "has_slot_data": [("logic", 0, "not")],
+        "update_stage_flags": SPAWN_B3_REAPLING_FLAGS
     },
 }
 

--- a/worlds/tloz_ph/data/DynamicFlags.py
+++ b/worlds/tloz_ph/data/DynamicFlags.py
@@ -417,6 +417,11 @@ DYNAMIC_FLAGS = {
         "has_items": [("Courage Crest", 0)],
         "unset_if_true": [(PHAddr.adv_flags_16, 0x04)]
     },
+    "Prevent early courage crest location": {
+        "on_scenes": [0],
+        "not_has_locations": ['Ocean SW Salvage Courage Crest'],
+        "unset_if_true": [(PHAddr.adv_flags_2, 0x40)]
+    },
     # Endgame
     "Spawn Phantoms in Totok B13": {
         "on_scenes": [0x2511],
@@ -1154,6 +1159,11 @@ DYNAMIC_FLAGS = {
         "on_scenes": [0x2900],
         "check_bits": [(PHAddr.flags_clear_fog, 0x10)],
         "set_if_true": [(PHAddr.adv_flags_7, 0x40)]
+    },
+    "Ghost ship block warp": {
+        "on_scenes": [0x2900],
+        "check_bits": [(PHAddr.flags_clear_fog, 0x10, "not")],
+        "unset_if_true": [(PHAddr.adv_flags_7, 0x40)]
     },
     # Vanilla frogs
     "Frogs show glyph": {

--- a/worlds/tloz_ph/data/Entrances.py
+++ b/worlds/tloz_ph/data/Entrances.py
@@ -2189,6 +2189,16 @@ EVENT_DATA = {
         "direction": EntranceGroups.NONE,
         "island": EntranceGroups.NONE,
     },
+    "EVENT: Defeat Cubus Sisters": {
+        "two_way": False,
+        "entrance_region": "Post Cubus Sisters",
+        "exit_region": "Post Cubus Sisters Event",
+        "extra_data": {"shared_event": True},
+        "entrance": (0x4, 0x0, 0x0),
+        "type": EntranceGroups.EVENT,
+        "direction": EntranceGroups.NONE,
+        "island": EntranceGroups.NONE,
+    }
 }
 
 

--- a/worlds/tloz_ph/data/Items.py
+++ b/worlds/tloz_ph/data/Items.py
@@ -173,6 +173,7 @@ ITEMS_DATA = {
         "model": 0x2d,
         "model_reset": True,
         "ghost_model": True,
+        "blocked_scenes": [0x1701],
         "item_groups": ["Spirit of Power", "Spirits", "SoP", "Upgrades"],
     },
     "Spirit of Wisdom (Progressive)": {
@@ -182,6 +183,7 @@ ITEMS_DATA = {
         "model": 0x2e,
         "model_reset": True,
         "ghost_model": True,
+        "blocked_scenes": [0x1701],
         "item_groups": ["Spirit of Wisdom", "Spirits", "SoW", "Upgrades"],
     },
     "Spirit of Courage (Progressive)": {
@@ -191,6 +193,7 @@ ITEMS_DATA = {
         "model": 0x2F,
         "model_reset": True,
         "ghost_model": True,
+        "blocked_scenes": [0x1701],
         "item_groups": ["Spirit of Courage", "Spirits", "SoC", "Upgrades"],
     },
     "Spirit of Courage (White)": {  # Used to remove spirit from Temple of Courage
@@ -228,7 +231,7 @@ ITEMS_DATA = {
     "Sand of Hours (Boss)": {
         "classification": DEPRIORITIZED_SKIP_BALANCING_FALLBACK,
         "address": PHAddr.phantom_hourglass_max,
-        "value": 0x1c20,
+        "value": "Sand", # 0x1c20,
         "tags": ["monotone_incremental", "backup_filler"],
         "size": 4,
         "id": 18,
@@ -239,7 +242,7 @@ ITEMS_DATA = {
     "Sand of Hours (Small)": {
         "classification": DEPRIORITIZED_SKIP_BALANCING_FALLBACK,
         "address": PHAddr.phantom_hourglass_max,
-        "value": 0xe10,
+        "value": "Sand", # 0xe10,
         "tags": ["monotone_incremental", "backup_filler"],
         "size": 4,
         "id": 19,
@@ -393,7 +396,7 @@ ITEMS_DATA = {
         "classification": DEPRIORITIZED_SKIP_BALANCING_FALLBACK,
         "address": PHAddr.power_gem_count,
         "value": 0x1,
-        "tags": ["incremental"],
+        "tags": ["monotone_incremental"],
         "id": 32,
         "model": 0x2D,
         "item_groups": ["Spirit Gems", "Single Spirit Gems", "Power Gems"],
@@ -402,7 +405,7 @@ ITEMS_DATA = {
         "classification": DEPRIORITIZED_SKIP_BALANCING_FALLBACK,
         "address": PHAddr.wisdom_gem_count,
         "value": 0x1,
-        "tags": ["incremental"],
+        "tags": ["monotone_incremental"],
         "id": 33,
         "model": 0x2E,
         "item_groups": ["Spirit Gems", "Single Spirit Gems", "Wisdom Gems"],
@@ -411,7 +414,7 @@ ITEMS_DATA = {
         "classification": DEPRIORITIZED_SKIP_BALANCING_FALLBACK,
         "address": PHAddr.courage_gem_count,
         "value": 0x1,
-        "tags": ["incremental"],
+        "tags": ["monotone_incremental"],
         "id": 34,
         "model": 0x2F,
         "item_groups": ["Spirit Gems", "Single Spirit Gems", "Courage Gems"],
@@ -588,7 +591,7 @@ ITEMS_DATA = {
         "dummy": True,
         "id": 53,
         "model": 0x0,
-        "item_groups": ["Technical Items", "Potions"],
+        "item_groups": ["Technical Items"],
     },
     "Refill: Bombs": {
         "classification": ItemClassification.filler,
@@ -1152,7 +1155,8 @@ ITEMS_DATA = {
                                      ("stage_flag", 0x80)]},
         "model": 0x21,
         "model_reset": True,
-        "item_groups": ["Regular Crystal Items", "Square Crystal Items", "Square Crystal ToC"],
+        "item_groups": ["Regular Crystal Items", "Square Crystal Items", "Square Crystal ToC",
+                        "toc_sq_n", "toc_sq_s"],
     },
     "Square Pedestal North (Temple of Courage)": {
         "classification": ItemClassification.progression,
@@ -1162,7 +1166,7 @@ ITEMS_DATA = {
         "set_bit_in_room": {0x1E00: [(PHAddr.toc_crystal_state, 0x10)]},
         "model": 0x21,
         "model_reset": True,
-        "item_groups": ["Unique Crystal Items", "Square Crystal Items", "Square Crystal ToC"],
+        "item_groups": ["Unique Crystal Items", "Square Crystal Items", "Square Crystal ToC", "toc_sq_n"],
 
     },
     "Square Pedestal South (Temple of Courage)": {
@@ -1173,7 +1177,7 @@ ITEMS_DATA = {
         "set_bit_in_room": {0x1E00: [("stage_flag", 0x80)]},
         "model": 0x21,
         "model_reset": True,
-        "item_groups": ["Unique Crystal Items", "Square Crystal Items", "Square Crystal ToC"],
+        "item_groups": ["Unique Crystal Items", "Square Crystal Items", "Square Crystal ToC", "toc_sq_s"],
     },
     "Triangle Crystal (Ghost Ship)": {
         "classification": ItemClassification.progression,
@@ -1183,7 +1187,9 @@ ITEMS_DATA = {
         "set_bit_in_room": {0x2900: [("stage_flag", [0, 8])]},
         "model": 0x23,
         "model_reset": True,
-        "item_groups": ["Regular Crystal Items", "Unique Crystal Items", "Triangle Crystal Items", "Triangle Crystal GS"],
+        "item_groups": ["Regular Crystal Items", "Unique Crystal Items", "Triangle Crystal Items",
+                        "Triangle Crystal GS",
+                        "gs_tri"],
     },
     "Round Crystal (Ghost Ship)": {
         "classification": ItemClassification.progression,
@@ -1193,7 +1199,8 @@ ITEMS_DATA = {
         "set_bit_in_room": {0x2900: [("stage_flag", [0, 0, 0, 2])]},
         "model": 0x22,
         "model_reset": True,
-        "item_groups": ["Regular Crystal Items", "Unique Crystal Items", "Round Crystal Items", "Round Crystal GS"],
+        "item_groups": ["Regular Crystal Items", "Unique Crystal Items", "Round Crystal Items",
+                        "Round Crystal GS", "gs_round"],
     },
     "Round Crystal (Temple of the Ocean King)": {
         "classification": ItemClassification.progression,
@@ -1204,7 +1211,8 @@ ITEMS_DATA = {
                             0x250C: [(PHAddr.totok_b9_state, 0x4)]},
         "model": 0x22,
         "model_reset": True,
-        "item_groups": ["Regular Crystal Items", "Round Crystal Items", "Round Crystal TotOK"],
+        "item_groups": ["Regular Crystal Items", "Round Crystal Items",
+                        "Round Crystal TotOK", "totok_round_8", "totok_round_9"],
     },
     "Round Pedestal B8 (Temple of the Ocean King)": {
         "classification": ItemClassification.progression,
@@ -1214,7 +1222,8 @@ ITEMS_DATA = {
         "set_bit_in_room": {0x250B: [(PHAddr.totok_b8_state, 0x2)]},
         "model": 0x22,
         "model_reset": True,
-        "item_groups": ["Unique Crystal Items", "Round Crystal Items", "Round Crystal TotOK"],
+        "item_groups": ["Unique Crystal Items", "Round Crystal Items",
+                        "Round Crystal TotOK", "totok_round_8"],
     },
     "Round Pedestal B9 (Temple of the Ocean King)": {
         "classification": ItemClassification.progression,
@@ -1224,7 +1233,8 @@ ITEMS_DATA = {
         "set_bit_in_room": {0x250C: [(PHAddr.totok_b9_state, 0x4)]},
         "model": 0x22,
         "model_reset": True,
-        "item_groups": ["Unique Crystal Items", "Round Crystal Items", "Round Crystal TotOK"],
+        "item_groups": ["Unique Crystal Items", "Round Crystal Items",
+                        "Round Crystal TotOK", "totok_round_8", "totok_round_9"],
     },
     "Round Crystals": {
         "classification": ItemClassification.progression,
@@ -1236,7 +1246,8 @@ ITEMS_DATA = {
                             0x2900: [("stage_flag", [0, 0, 0, 2])]},
         "model": 0x22,
         "model_reset": True,
-        "item_groups": ["Global Crystal Items", "Round Crystal Items"],
+        "item_groups": ["Global Crystal Items", "Round Crystal Items",
+                        "totok_round_8", "totok_round_9", "gs_round"],
     },
     "Triangle Crystal (Temple of the Ocean King)": {
         "classification": ItemClassification.progression,
@@ -1247,7 +1258,8 @@ ITEMS_DATA = {
                             0x250C: [(PHAddr.totok_b9_state, 0x8)]},
         "model": 0x23,
         "model_reset": True,
-        "item_groups": ["Regular Crystal Items", "Triangle Crystal Items", "Triangle Crystal TotOK"],
+        "item_groups": ["Regular Crystal Items", "Triangle Crystal Items", "Triangle Crystal TotOK",
+                        "totok_tri_8", "totok_tri_9"],
     },
     "Triangle Pedestal B8 (Temple of the Ocean King)": {
         "classification": ItemClassification.progression,
@@ -1257,7 +1269,7 @@ ITEMS_DATA = {
         "set_bit_in_room": {0x250B: [(PHAddr.totok_b8_state, 0x4)]},
         "model": 0x23,
         "model_reset": True,
-        "item_groups": ["Unique Crystal Items", "Triangle Crystal Items", "Triangle Crystal TotOK"],
+        "item_groups": ["Unique Crystal Items", "Triangle Crystal Items", "Triangle Crystal TotOK", "totok_tri_8"],
     },
     "Triangle Pedestal B9 (Temple of the Ocean King)": {
         "classification": ItemClassification.progression,
@@ -1267,7 +1279,7 @@ ITEMS_DATA = {
         "set_bit_in_room": {0x250C: [(PHAddr.totok_b9_state, 0x8)]},
         "model": 0x23,
         "model_reset": True,
-        "item_groups": ["Unique Crystal Items", "Triangle Crystal Items", "Triangle Crystal TotOK"],
+        "item_groups": ["Unique Crystal Items", "Triangle Crystal Items", "Triangle Crystal TotOK", "totok_tri_9"],
     },
     "Triangle Crystals": {
         "classification": ItemClassification.progression,
@@ -1279,7 +1291,8 @@ ITEMS_DATA = {
                             0x2900: [("stage_flag", [0, 8])]},
         "model": 0x23,
         "model_reset": True,
-        "item_groups": ["Global Crystal Items", "Triangle Crystal Items"],
+        "item_groups": ["Global Crystal Items", "Triangle Crystal Items",
+                        "totok_tri_8", "totok_tri_9", "gs_tri"],
     },
     "Square Crystal (Temple of the Ocean King)": {
         "classification": ItemClassification.progression,
@@ -1289,7 +1302,8 @@ ITEMS_DATA = {
         "set_bit_in_room": {0x250C: [(PHAddr.totok_b9_state, 0x22)]},
         "model": 0x21,
         "model_reset": True,
-        "item_groups": ["Regular Crystal Items", "Square Crystal Items", "Square Crystal TotOK"],
+        "item_groups": ["Regular Crystal Items", "Square Crystal Items", "Square Crystal TotOK",
+                        "totok_sq_w", "totok_sq_e"],
     },
     "Square Pedestal West (Temple of the Ocean King)": {
         "classification": ItemClassification.progression,
@@ -1299,7 +1313,9 @@ ITEMS_DATA = {
         "set_bit_in_room": {0x250C: [(PHAddr.totok_b9_state, 0x20)]},
         "model": 0x21,
         "model_reset": True,
-        "item_groups": ["Unique Crystal Items", "Square Crystal Items", "Square Crystal TotOK"],
+        "item_groups": ["Unique Crystal Items", "Square Crystal Items", "Square Crystal TotOK",
+                        "totok_sq_w"
+                        ],
     },
     "Square Pedestal Center (Temple of the Ocean King)": {
         "classification": ItemClassification.progression,
@@ -1309,7 +1325,8 @@ ITEMS_DATA = {
         "set_bit_in_room": {0x250C: [(PHAddr.totok_b9_state, 0x2)]},
         "model": 0x21,
         "model_reset": True,
-        "item_groups": ["Unique Crystal Items", "Square Crystal Items", "Square Crystal TotOK"],
+        "item_groups": ["Unique Crystal Items", "Square Crystal Items", "Square Crystal TotOK",
+                        "totok_sq_e"],
     },
     "Square Crystals": {
         "classification": ItemClassification.progression,
@@ -1321,7 +1338,8 @@ ITEMS_DATA = {
                                      ("stage_flag", 0x80)]},
         "model": 0x21,
         "model_reset": True,
-        "item_groups": ["Global Crystal Items", "Square Crystal Items"],
+        "item_groups": ["Global Crystal Items", "Square Crystal Items",
+                        "totok_sq_e", "totok_sq_w", "toc_sq_n", "toc_sq_s"],
     },
     "Force Gem (B3)": {
         "classification": ItemClassification.progression,

--- a/worlds/tloz_ph/data/Locations.py
+++ b/worlds/tloz_ph/data/Locations.py
@@ -178,6 +178,7 @@ LOCATIONS_DATA = {
         "address": PHAddr.adv_flags_41,
         "value": 0x2,
         "delay_reset": True,
+        "conditional": True,  # Removed until fixed
         "id": 15,
         "hint_entrance": "Oshus' Exit",
         "gift_addr": Address(0x2153FC)  # Resets after getting phantom sword, annoying...
@@ -2375,6 +2376,8 @@ LOCATIONS_DATA = {
         "vanilla_item": "Ghost Key",
         "boss_room": "Ghost Ship",
         "id": 184,
+        "do_special": {"event_type": "ut_connect",
+                       "event_name": "EVENT: Defeat Cubus Sisters"},
         "hint_entrance": "Cubus Sisters Blue Warp",
         "hint_entrance_secondary": "GS Exit"
     },
@@ -3244,6 +3247,7 @@ LOCATIONS_DATA = {
         "vanilla_item": "Power Gem",
         "stage_id": 0x12,
         "floor_id": 0x1,
+        "additional_rooms": [0x1101],
         "y": 0x0,
         "id": 254,
         "chest_offset": 15
@@ -3303,6 +3307,7 @@ LOCATIONS_DATA = {
         "vanilla_item": "Big Red Rupee (200)",
         "stage_id": 0x12,
         "floor_id": 0x1,
+        "additional_rooms": [0x1101],
         "y": 4915,
         "x_min": -44500,
         "z_min": -35000,

--- a/worlds/tloz_ph/data/LogicPredicates.py
+++ b/worlds/tloz_ph/data/LogicPredicates.py
@@ -64,9 +64,11 @@ def ph_has_spirit(state: CollectionState, player: int, spirit: str, count: int =
 
 
 def ph_has_spirit_gems(state: CollectionState, player: int, spirit: str, count: int = 1):
-    pack_size = state.multiworld.worlds[player].options.spirit_gem_packs
+    pack_size = state.multiworld.worlds[player].options.spirit_gem_packs.value
+    spirits = ["Power", "Wisdom", "Courage"]
+    spirit_index = spirits.index(spirit)
     return all([
-        ph_has_spirit(state, player, spirit),
+        any([ph_has_spirit(state, player, s) for s in spirits[spirit_index:]]),
         any([
             state.has(f"{spirit} Gem", player, count),
             state.has(f"{spirit} Gem Pack", player, ceil(count / pack_size)),

--- a/worlds/tloz_ph/test/bases.py
+++ b/worlds/tloz_ph/test/bases.py
@@ -35,13 +35,14 @@ from test.bases import *
 #                }
 
 options_metal_bug = {
-        "goal_requirements": "defeat_bosses",
-        "bellum_access": "spawn_bellumbeck",
-        "dungeons_required": 7,
-        "require_specific_bosses": False,
-        "exclude_non_required_dungeons": False,
-        "ghost_ship_in_dungeon_pool": False,
-        "totok_in_dungeon_pool": False,
+    "goal_requirements": "defeat_bosses",
+    "bellum_access": "spawn_bellumbeck",
+    "dungeons_required": 7,
+    "require_specific_bosses": False,
+    "exclude_non_required_dungeons": False,
+    "ghost_ship_in_dungeon_pool": False,
+    "totok_in_dungeon_pool": False,
+    "exclude_locations": ["Temple of the Ocean King"],
 
     "keysanity": "in_own_dungeon",
     "randomize_pedestal_items": "vanilla_abstract",

--- a/worlds/tloz_ph/tracker/locations/locations.json
+++ b/worlds/tloz_ph/tracker/locations/locations.json
@@ -2018,6 +2018,9 @@
     "sections": [
       {
         "name": "EVENT: Rescue Tetra"
+      },
+            {
+        "name": "EVENT: Defeat Cubus Sisters"
       }
     ],
     "map_locations": [

--- a/worlds/tloz_ph/tracker/locations/overview_bosses.json
+++ b/worlds/tloz_ph/tracker/locations/overview_bosses.json
@@ -1,5 +1,6 @@
 [
 { "name": "Bosses - Ghost Ship B1", "sections": [{ "name": "Cubus Sisters Ghost Key" }, { "name": "Cubus Sisters Heart Container" }], "map_locations": [{ "map": "Ghost Ship B1", "x": 38, "y": 86 }] },
+  { "name": "Bosses - Ghost Ship B1 Event", "sections": [{ "name": "EVENT: Defeat Cubus Sisters" }], "map_locations": [{ "map": "Ghost Ship B1", "x": 38, "y": 78 }] },
 { "name": "Bosses - Goron Temple B3", "sections": [{ "name": "Dongorongo Boss Reward" }, { "name": "Dongorongo Heart Container" }, { "name": "Dongorongo Sand of Hours" }], "map_locations": [{ "map": "Goron Temple B3", "x": 176, "y": 116 }] },
 { "name": "Bosses - Mutoh's Temple B2", "sections": [{ "name": "Eox Boss Reward" }, { "name": "Eox Heart Container" }, { "name": "Eox Sand of Hours" }], "map_locations": [{ "map": "Mutoh's Temple B2", "x": 128, "y": 56 }] },
 { "name": "Bosses - Temple of Courage 2F", "sections": [{ "name": "Crayk Boss Reward" }, { "name": "Crayk Heart Container" }, { "name": "Crayk Sand of Hours" }], "map_locations": [{ "map": "Temple of Courage 2F", "x": 108, "y": 88 }] },


### PR DESCRIPTION
# 9.5 Changelog
- Link remains in control during lots of small cutscenes, like opening doors and spawning chests
  - Added a yaml option to toggle chest spawning cutscenes, cause you get zero feedback with skips on.
- Fixed read locations stealing items that share models, mainly affecting spirit gems
- Fixed keys being buggy when received in dungeons
- Restarting the client in TotOK no longer sends extra keys
- Removed Oshus gem location until i figure out how to fix the softlock
- Added extra debugging info to instant-goal, cause it sometimes sends early
- Fixed salvage courage crest location sending early after getting the sun key
- Blocked map warping to an ocean quadrant with the salvage arm, cause it softlocks.
- Removed "Nothing!" from potion pool
- Prevented receiving spirits in spirit room from sending spirit locations
- Logic for spirit locations allows for getting spirit rewards from earlier spirits with later ones
- Added missing UT boss event for Cubus Sisters
- Defeating the Cubus Sisters outside the ghost ship no longer spawns their warp
- Fixed a logic bug in ToW
- Removed a rogue event from the `Temple of the Ocean King` location group, allowing you to use it in the yaml.
- Prevented goal from sending early when dying and reviving on Bellumbeck